### PR TITLE
feat: Add JSON and CSV importer/export

### DIFF
--- a/Neighborly/ETL/ContentType.cs
+++ b/Neighborly/ETL/ContentType.cs
@@ -1,15 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Neighborly.ETL;
 
-namespace Neighborly.ETL
+public enum ContentType
 {
-    public enum ContentType
-    {
-        HDF5,       // Hierarchical Data Format version 5
-        CSV,        // Comma Separated Values
-        Parquet     // Apache Parquet
-    }
+    HDF5,       // Hierarchical Data Format version 5
+    CSV,        // Comma Separated Values
+    Parquet,    // Apache Parquet
+    JSON,        // JSON encoded vectors
+    JSONZ       // JSON encoded vectors with GZip compression
 }

--- a/Neighborly/ETL/Csv.cs
+++ b/Neighborly/ETL/Csv.cs
@@ -1,29 +1,87 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Globalization;
 using System.Text;
-using System.Threading.Tasks;
+using CsvHelper;
+using CsvHelper.Configuration;
+using CsvHelper.Configuration.Attributes;
+using CsvHelper.TypeConversion;
 
-namespace Neighborly.ETL
+namespace Neighborly.ETL;
+
+/// <summary>
+/// ETL operation for importing and exporting Comma Separated Values (CSV).
+/// </summary>
+public sealed class Csv : EtlBase
 {
-    /// <summary>
-    /// ETL operation for importing and exporting Comma Separated Values (CSV).
-    /// </summary>
-    public class Csv : IETL
+    private static readonly CsvConfiguration s_configuration = new(CultureInfo.InvariantCulture)
     {
-        public bool isDirectory { get; set; }
-        public string fileExtension => ".csv";
-        public VectorDatabase vectorDatabase { get; set; }
+        HasHeaderRecord = true,
+        Delimiter = ";",
+        IgnoreBlankLines = true,
+        IgnoreReferences = true,
+        TrimOptions = TrimOptions.Trim,
+        Encoding = Encoding.UTF8
+    };
 
-        public Task ExportDataAsync(string path)
+    /// <inheritdoc />
+    public override string FileExtension => ".csv";
+
+    /// <inheritdoc />
+    public async override Task ExportDataAsync(IEnumerable<Vector> vectors, string path, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(vectors);
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        using var stream = CreateWriteStream(path);
+        using var textWriter = new StreamWriter(stream, Encoding.UTF8);
+        using var writer = new CsvWriter(textWriter, s_configuration);
+        writer.Context.RegisterClassMap<VectorRecordMap>();
+        await writer.WriteRecordsAsync(vectors.Select(ConvertToRecord), cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    protected async override Task ImportFileAsync(string path, ICollection<Vector> vectors, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(vectors);
+
+        using var stream = CreateReadStream(path);
+        using var textReader = new StreamReader(stream, Encoding.UTF8);
+        using var reader = new CsvReader(textReader, s_configuration);
+        reader.Context.RegisterClassMap<VectorRecordMap>();
+        await foreach (var record in reader.EnumerateRecordsAsync(new VectorRecord(Guid.Empty, [], [], string.Empty), cancellationToken).ConfigureAwait(false))
         {
-            throw new NotImplementedException();
+            vectors.Add(new Vector(record.Id, record.Values, record.Tags ?? [], record.OriginalText ?? string.Empty));
+        }
+    }
+
+    private static VectorRecord ConvertToRecord(Vector vector) => new(vector.Id, vector.Values, vector.Tags, vector.OriginalText);
+
+    private record class VectorRecord(Guid Id, [property: TypeConverter(typeof(ArrayConverter))] float[] Values, [property: TypeConverter(typeof(ArrayConverter))] short[] Tags, string? OriginalText);
+
+    private class VectorRecordMap : ClassMap<VectorRecord>
+    {
+        public VectorRecordMap()
+        {
+            Map(v => v.Id).Name(nameof(VectorRecord.Id));
+            Map(v => v.Values).Name(nameof(VectorRecord.Values)).TypeConverter<ArrayConverter<float>>();
+            Map(v => v.Tags).Name(nameof(VectorRecord.Tags)).TypeConverter<ArrayConverter<short>>();
+            Map(v => v.OriginalText).Name(nameof(VectorRecord.OriginalText));
         }
 
-        public Task ImportDataAsync(string path)
+        private class ArrayConverter<T> : ArrayConverter
         {
-            throw new NotImplementedException();
+            private const char s_separator = ',';
+
+            public override object? ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
+                => text?.Split(s_separator)
+                .Where(static s => !string.IsNullOrWhiteSpace(s))
+                .Select(static s => (T?)System.ComponentModel.TypeDescriptor.GetConverter(typeof(T)).ConvertFromString(s))
+                .Where(static v => v != null)
+                .ToArray();
+
+            public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+                => string.Join(s_separator, ((IEnumerable<T>)value).Select(static v => v?.ToString()));
         }
     }
 }
-    
+

--- a/Neighborly/ETL/EtlBase.cs
+++ b/Neighborly/ETL/EtlBase.cs
@@ -1,0 +1,44 @@
+﻿namespace Neighborly.ETL;
+
+public abstract class EtlBase : IETL
+{
+    /// <inheritdoc />
+    public bool IsDirectory { get; set; }
+
+    /// <inheritdoc />
+    public abstract string FileExtension { get; }
+
+    /// <inheritdoc />
+    public abstract Task ExportDataAsync(IEnumerable<Vector> vectors, string path, CancellationToken cancellationToken);
+
+    /// <inheritdoc />
+    public Task ImportDataAsync(string path, ICollection<Vector> vectors, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(vectors);
+
+        if (IsDirectory)
+        {
+            return ImportDirectoryAsync(path, vectors, cancellationToken);
+        }
+        else
+        {
+            return ImportFileAsync(path, vectors, cancellationToken);
+        }
+    }
+
+    protected abstract Task ImportFileAsync(string path, ICollection<Vector> vectors, CancellationToken cancellationToken);
+
+    private async Task ImportDirectoryAsync(string path, ICollection<Vector> vectors, CancellationToken cancellationToken)
+    {
+        foreach (string file in Directory.EnumerateFiles(path, $"*{FileExtension}"))
+        {
+            await ImportFileAsync(file, vectors, cancellationToken);
+        }
+    }
+
+
+    protected virtual Stream CreateWriteStream(string path) => new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true);
+
+    protected virtual Stream CreateReadStream(string path) => new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true);
+}

--- a/Neighborly/ETL/EtlFactory.cs
+++ b/Neighborly/ETL/EtlFactory.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel;
+
+namespace Neighborly.ETL;
+
+public static class EtlFactory
+{
+    public static IETL CreateEtl(ContentType contentType)
+    {
+        if (!Enum.IsDefined(contentType))
+        {
+            throw new InvalidEnumArgumentException(nameof(contentType), (int)contentType, typeof(ETL.ContentType));
+        }
+
+        return contentType switch
+        {
+            ContentType.HDF5 => new HDF5(),
+            ContentType.CSV => new Csv(),
+            ContentType.Parquet => new Parquet(),
+            ContentType.JSON => new JSON(),
+            ContentType.JSONZ => new JSONZ(),
+            _ => throw new NotSupportedException($"Content type {contentType} is not supported."),
+        };
+    }
+}

--- a/Neighborly/ETL/HDF5.cs
+++ b/Neighborly/ETL/HDF5.cs
@@ -4,25 +4,25 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Neighborly.ETL
+namespace Neighborly.ETL;
+
+/// <summary>
+/// ETL operation for importing and exporting Hierarchical Data Format version 5 (HDF5).
+/// </summary>
+public sealed class HDF5 : EtlBase
 {
-    /// <summary>
-    /// ETL operation for importing and exporting Hierarchical Data Format version 5 (HDF5).
-    /// </summary>
-    public class HDF5 : IETL
+    /// <inheritdoc />
+    public override string FileExtension => ".h5";
+
+    /// <inheritdoc />
+    public override Task ExportDataAsync(IEnumerable<Vector> vectors, string path, CancellationToken cancellationToken = default)
     {
-        public bool isDirectory { get; set; }
-        public string fileExtension => ".h5";
-        public VectorDatabase vectorDatabase { get; set; }
+        throw new NotImplementedException();
+    }
 
-        public Task ExportDataAsync(string path)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task ImportDataAsync(string path)
-        {
-            throw new NotImplementedException();
-        }
+    /// <inheritdoc />
+    protected override Task ImportFileAsync(string path, ICollection<Vector> vectors, CancellationToken cancellationToken= default)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/Neighborly/ETL/IETL.cs
+++ b/Neighborly/ETL/IETL.cs
@@ -1,23 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Neighborly.ETL;
 
-namespace Neighborly.ETL
+/// <summary>
+/// VectorDatabase Interface for Extract Transform and Load (ETL) operations for importing and exporting Vector data.
+/// </summary>
+public interface IETL
 {
     /// <summary>
-    /// VectorDatabase Interface for Extract Transform and Load (ETL) operations for importing and exporting Vector data.
+    /// Indicates if the ETL operation should be performed on a directory or a file.
     /// </summary>
-    public interface IETL
-    {
-        /// <summary>
-        /// Indicates if the ETL operation should be performed on a directory or a file.
-        /// </summary>
-        bool isDirectory { get; set; }
-        string fileExtension { get; }
-        VectorDatabase vectorDatabase{ get; set; }
-        public Task ImportDataAsync(string path);
-        public Task ExportDataAsync(string path);
-    }
+    bool IsDirectory { get; set; }
+    string FileExtension { get; }
+    public Task ImportDataAsync(string path, ICollection<Vector> vectors,  CancellationToken cancellationToken = default);
+    public Task ExportDataAsync(IEnumerable<Vector> vectors, string path,  CancellationToken cancellationToken = default);
 }

--- a/Neighborly/ETL/JSON.cs
+++ b/Neighborly/ETL/JSON.cs
@@ -1,0 +1,34 @@
+﻿using System.Text.Json;
+
+namespace Neighborly.ETL;
+
+public class JSON : EtlBase
+{
+    /// <inheritdoc />
+    public override string FileExtension => ".json";
+
+    /// <inheritdoc />
+    public sealed override async Task ExportDataAsync(IEnumerable<Vector> vectors, string path, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(vectors);
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        using var stream = CreateWriteStream(path);
+        await JsonSerializer.SerializeAsync(stream, vectors.Select(ConvertToRecord), cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    protected sealed override async Task ImportFileAsync(string path, ICollection<Vector> vectors, CancellationToken cancellationToken)
+    {
+        using var stream = CreateReadStream(path);
+        await foreach (VectorRecord record in JsonSerializer.DeserializeAsyncEnumerable<VectorRecord>(stream, cancellationToken: cancellationToken))
+        {
+            Vector vector = new(record.I, record.V, record.T ?? [], record.O);
+            vectors.Add(vector);
+        }
+    }
+
+    private static VectorRecord ConvertToRecord(Vector vector) => new(vector.Id, vector.Values, vector.Tags, vector.OriginalText);
+
+    private readonly record struct VectorRecord(Guid I, float[] V, short[] T, string? O);
+}

--- a/Neighborly/ETL/JSONZ.cs
+++ b/Neighborly/ETL/JSONZ.cs
@@ -1,0 +1,15 @@
+﻿using System.IO.Compression;
+
+namespace Neighborly.ETL;
+
+public sealed class JSONZ : JSON
+{
+    /// <inheritdoc />
+    public override string FileExtension => ".json.gz";
+
+    /// <inheritdoc />
+    protected override Stream CreateReadStream(string path) => new GZipStream(base.CreateReadStream(path), CompressionMode.Decompress);
+
+    /// <inheritdoc />
+    protected override Stream CreateWriteStream(string path) => new GZipStream(base.CreateWriteStream(path), CompressionLevel.Fastest);
+}

--- a/Neighborly/Neighborly.csproj
+++ b/Neighborly/Neighborly.csproj
@@ -25,9 +25,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CsvHelper" Version="32.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageReference Include="Parquet.Net" Version="4.23.5" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="8.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.3" />
   </ItemGroup>
 </Project>

--- a/Neighborly/Vector.cs
+++ b/Neighborly/Vector.cs
@@ -142,6 +142,17 @@ public partial class Vector : IEquatable<Vector>
         Tags = tags;
     }
 
+    internal Vector(Guid id, float[] values, short[] tags, string? originalText)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        ArgumentNullException.ThrowIfNull(tags);
+
+        Id = id;
+        Values = values;
+        Tags = tags;
+        OriginalText = originalText ?? string.Empty;
+    }
+
     /// <summary>
     /// Gets the dimension of the vector.
     /// </summary>

--- a/Neighborly/VectorList.cs
+++ b/Neighborly/VectorList.cs
@@ -42,6 +42,8 @@ public class VectorList : IList<Vector>, IDisposable
         {
             if (disposing)
             {
+                IsReadOnly = true;
+
                 // Dispose managed resources.
                 _vectorList.Clear();
             }
@@ -73,7 +75,7 @@ public class VectorList : IList<Vector>, IDisposable
     /// Creates a new instance and Sets the maximum in-memory count.
     /// </summary>
     /// <param name="maxInMemoryCount"></param>
-    public VectorList(int maxInMemoryCount)
+    public VectorList(int maxInMemoryCount) : this()
     {
         _maxInMemoryCount = maxInMemoryCount;
     }
@@ -206,10 +208,7 @@ public class VectorList : IList<Vector>, IDisposable
             return -1;
         }
     }
-    public bool IsReadOnly
-    {
-        get { return false; } // This list is not read-only
-    }
+    public bool IsReadOnly { get; private set; }
     public List<Vector> FindAll(Predicate<Vector> match)
     {
         lock (_lock)
@@ -382,8 +381,8 @@ public class VectorList : IList<Vector>, IDisposable
                     throw new FileNotFoundException();
             }
         }
-
     }
+
     public void RemoveAt(int index)
     {
         lock (_lock)
@@ -589,5 +588,4 @@ public class VectorList : IList<Vector>, IDisposable
         }
 
     }
-
 }

--- a/Tests/ETLTest.cs
+++ b/Tests/ETLTest.cs
@@ -1,0 +1,50 @@
+﻿using Neighborly.ETL;
+
+namespace Neighborly.Tests.ETL;
+
+[TestFixture]
+public class ETLTest
+{
+    public static IReadOnlyList<IETL> EtlImplementations =
+    [
+        new Csv(), new HDF5(), new JSON(), new JSONZ(), new Neighborly.ETL.Parquet()
+    ];
+
+    [TestCaseSource(nameof(EtlImplementations))]
+    public async Task Can_SaveAndLoad_Vectors(IETL etl)
+    {
+        // Arrange,
+        var vectors = new List<Vector>
+        {
+            new([ 1f, 2, 3 ], "Original Text 1"),
+            new([ 4f, 5, 6 ], "Original Text 2"),
+            new([ 7f, 8, 9 ], "Original Text 3")
+        };
+
+        var path = Path.GetTempFileName();
+        try
+        {
+            // Act
+            await etl.ExportDataAsync(vectors, path).ConfigureAwait(true);
+            var loadedVectors = new List<Vector>();
+            await etl.ImportDataAsync(path, loadedVectors).ConfigureAwait(true);
+
+            // Assert
+            Assert.That(vectors, Has.Count.EqualTo(loadedVectors.Count));
+            for (int i = 0; i < vectors.Count; i++)
+            {
+                Assert.Multiple(() =>
+                {
+                    Assert.That(vectors[i].Id, Is.EqualTo(loadedVectors[i].Id));
+                    Assert.That(vectors[i].Values, Is.EqualTo(loadedVectors[i].Values));
+                    Assert.That(vectors[i].Tags, Is.EqualTo(loadedVectors[i].Tags));
+                    Assert.That(vectors[i].OriginalText, Is.EqualTo(loadedVectors[i].OriginalText));
+                });
+            }
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/Tests/VectorTests.cs
+++ b/Tests/VectorTests.cs
@@ -43,6 +43,7 @@ public class VectorTests
         Assert.That(newVector.Values, Is.EqualTo(originalVector.Values));
         Assert.That(newVector.Tags, Is.EqualTo(originalVector.Tags));
         Assert.That(newBinary, Is.EqualTo(binary));
+    }
 
     public void InPlaceAdd()
     {


### PR DESCRIPTION
## 📝 Description

Adds import and export for the formats `.json`, `.json.gz`, and `.csv`. To do this without too much uselessly redundant code,  some refactoring was done.

## 🔗 Related Issues

Contributes to #25

## 💡 Additional Notes

- Added a separate ETL class for `.json.gz` files, which just uses a gzip-stream
- JSON properties are shortened, as redundant field names in plain JSON files can add up to a lot of data.
- For CSV, a quick search didn't lead me to standardized format. This is just a suggestion to start with.
- Parquet and HDF5 will still need an implementation, but I didn't want to make this PR too big, and would have to research those formats a bit more.