### PR TITLE
feat: Add MemoryMappedList

### DIFF
--- a/Adapters.SemanticKernel/NeighborlyMemoryStore.cs
+++ b/Adapters.SemanticKernel/NeighborlyMemoryStore.cs
@@ -71,7 +71,7 @@ namespace NeighborlyMemory
 
         public Task<List<string>> GetKeysAsync()
         {
-            var keys = _vectorDatabase.Vectors.Guids.Select(id => id.ToString()).ToList();
+            var keys = _vectorDatabase.Vectors.Select(id => id.Id.ToString()).ToList();
             return Task.FromResult(keys);
         }
 

--- a/Neighborly/MemoryMappedList.cs
+++ b/Neighborly/MemoryMappedList.cs
@@ -1,0 +1,432 @@
+using System.Collections;
+using System.IO.MemoryMappedFiles;
+
+namespace Neighborly;
+
+public class MemoryMappedList : IDisposable, IEnumerable<Vector>
+{
+    private const int s_idBytesLength = 16;
+    private const int s_offsetBytesLength = sizeof(long);
+    private const int s_lengthBytesLength = sizeof(int);
+    private const int s_indexEntryByteLength = s_idBytesLength + s_offsetBytesLength + s_lengthBytesLength;
+    private static readonly Guid s_tombStone;
+    private static readonly byte[] s_tombStoneBytes;
+    private readonly MemoryMappedFileHolder _indexFile;
+    private readonly MemoryMappedFileHolder _dataFile;
+    private readonly object _mutex = new();
+    private long _count;
+    private bool _disposedValue;
+
+    static MemoryMappedList()
+    {
+        s_tombStone = Guid.NewGuid();
+
+        Span<byte> tombStoneBytes = stackalloc byte[16];
+        if (!s_tombStone.TryWriteBytes(tombStoneBytes))
+        {
+            throw new InvalidOperationException("Failed to write the tombstone to bytes");
+        }
+
+        s_tombStoneBytes = tombStoneBytes.ToArray();
+    }
+
+    public MemoryMappedList(long capacity)
+    {
+        _indexFile = new(s_indexEntryByteLength * capacity);
+        // Based on typical vector dimensions, 4096 bytes should be enough for most cases as of 2024-06
+        _dataFile = new(4096L * capacity);
+    }
+
+    public long Count
+    {
+        get
+        {
+            lock (_mutex)
+            {
+                return _count;
+            }
+        }
+    }
+
+#pragma warning disable CA1822 // Mark members as static - mimmicking ICollection<Vector>
+    public bool IsReadOnly => false;
+#pragma warning restore CA1822 // Mark members as static - mimmicking ICollection<Vector>
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposedValue)
+        {
+            if (disposing)
+            {
+                _dataFile.Dispose();
+                _indexFile.Dispose();
+            }
+
+            _disposedValue = true;
+        }
+    }
+
+    ~MemoryMappedList()
+    {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: false);
+    }
+
+    public void Dispose()
+    {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+
+    public Vector? GetVector(long index)
+    {
+        lock (_mutex)
+        {
+            if (index < 0L || index >= _count)
+            {
+                return null;
+            }
+
+            _indexFile.Stream.Seek(index * s_indexEntryByteLength, SeekOrigin.Begin);
+            Span<byte> entry = stackalloc byte[s_indexEntryByteLength];
+            _indexFile.Stream.ReadExactly(entry);
+
+            Span<byte> offsetBytes = entry[s_idBytesLength..(s_idBytesLength + s_offsetBytesLength)];
+            Span<byte> lengthBytes = entry[(s_idBytesLength + s_offsetBytesLength)..];
+            long offset = BitConverter.ToInt64(offsetBytes);
+            int length = BitConverter.ToInt32(lengthBytes);
+
+            _dataFile.Stream.Seek(offset, SeekOrigin.Begin);
+            Span<byte> bytes = stackalloc byte[length];
+            _dataFile.Stream.ReadExactly(bytes);
+            return new Vector(bytes);
+        }
+    }
+
+    public Vector? GetVector(Guid id)
+    {
+        lock (_mutex)
+        {
+            (_, long offset, int length) = SearchVectorInIndex(id);
+            if (offset < 0L || length < 0L)
+            {
+                return null;
+            }
+
+            _dataFile.Stream.Seek(offset, SeekOrigin.Begin);
+            Span<byte> bytes = stackalloc byte[length];
+            _dataFile.Stream.ReadExactly(bytes);
+            return new Vector(bytes);
+        }
+    }
+
+    public void CopyTo(Vector[] array, int arrayIndex)
+    {
+        lock (_mutex)
+        {
+            if (array == null)
+            {
+                throw new ArgumentNullException(nameof(array), "Array cannot be null");
+            }
+
+            if (arrayIndex < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(arrayIndex), "Array index cannot be less than 0");
+            }
+
+            if (array.Length - arrayIndex < Count)
+            {
+                throw new ArgumentException("The number of elements in the list is greater than the available space from arrayIndex to the end of the destination array");
+            }
+
+            foreach (var item in this)
+            {
+                array[arrayIndex++] = item;
+            }
+        }
+    }
+
+    public long FindIndexById(Guid id)
+    {
+        lock (_mutex)
+        {
+            (long index, _, _) = SearchVectorInIndex(id);
+            return index;
+        }
+    }
+
+    public long IndexOf(Vector item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+
+        lock (_mutex)
+        {
+            (long index, _, _) = SearchVectorInIndex(item.Id);
+            return index;
+        }
+    }
+
+    public void Add(Vector vector)
+    {
+        ArgumentNullException.ThrowIfNull(vector);
+
+        lock (_mutex)
+        {
+            Span<byte> entry = stackalloc byte[s_indexEntryByteLength];
+            Span<byte> idBytes = entry[..s_idBytesLength];
+            if (!vector.Id.TryWriteBytes(idBytes))
+            {
+                throw new InvalidOperationException("Failed to write the Id to bytes");
+            }
+
+            Span<byte> offsetBytes = entry[s_idBytesLength..(s_idBytesLength + s_offsetBytesLength)];
+            if (!BitConverter.TryWriteBytes(offsetBytes, _dataFile.Stream.Position))
+            {
+                throw new InvalidOperationException("Failed to write the offset to bytes");
+            }
+
+            byte[] data = vector.ToBinary();
+            Span<byte> lengthBytes = entry[(s_idBytesLength + s_offsetBytesLength)..];
+            if (!BitConverter.TryWriteBytes(lengthBytes, data.Length))
+            {
+                throw new InvalidOperationException("Failed to write the length to bytes");
+            }
+
+            _indexFile.Stream.Write(entry);
+            _dataFile.Stream.Write(data);
+
+            ++_count;
+        }
+    }
+
+    public bool Remove(Vector vector)
+    {
+        ArgumentNullException.ThrowIfNull(vector);
+
+        lock (_mutex)
+        {
+            _indexFile.Stream.Seek(0, SeekOrigin.Begin);
+
+            Span<byte> entry = stackalloc byte[s_indexEntryByteLength];
+            int bytesRead;
+            while ((bytesRead = _indexFile.Stream.Read(entry)) > 0)
+            {
+                if (bytesRead != s_indexEntryByteLength)
+                {
+                    throw new InvalidOperationException("Failed to read the index entry");
+                }
+
+                Guid id = new(entry[..s_idBytesLength]);
+                if (id == vector.Id)
+                {
+                    // Seek to the beginning of the entry and remove the ID with a tombstone-ID
+                    _indexFile.Stream.Seek(-s_indexEntryByteLength, SeekOrigin.Current);
+                    _indexFile.Stream.Write(s_tombStoneBytes);
+                    // Seek to after the entry
+                    _indexFile.Stream.Seek(s_indexEntryByteLength - s_idBytesLength, SeekOrigin.Current);
+                    --_count;
+                    return true;
+                }
+                else if (id.Equals(Guid.Empty))
+                {
+                    break;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public bool Update(Vector vector)
+    {
+        ArgumentNullException.ThrowIfNull(vector);
+
+        lock (_mutex)
+        {
+            if (Remove(vector))
+            {
+                Add(vector);
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    public void Defrag()
+    {
+        // TODO: Implement defragmentation - remove tombstones and compact data
+        throw new NotImplementedException();
+    }
+
+    public void Clear()
+    {
+        lock (_mutex)
+        {
+            _indexFile.Reset();
+            _dataFile.Reset();
+            _count = 0;
+        }
+    }
+
+    public bool Contains(Vector item)
+    {
+        if (item is null)
+        {
+            return false;
+        }
+
+        var vector = GetVector(item.Id);
+        if (vector is null)
+        {
+            return false;
+        }
+
+        return vector.Equals(item);
+    }
+
+    public IEnumerator<Vector> GetEnumerator()
+    {
+        lock (_mutex)
+        {
+            _indexFile.Stream.Seek(0, SeekOrigin.Begin);
+            _dataFile.Stream.Seek(0, SeekOrigin.Begin);
+
+            byte[] entry = new byte[s_indexEntryByteLength];
+            int bytesRead;
+            while ((bytesRead = _indexFile.Stream.Read(entry, 0, entry.Length)) > 0)
+            {
+                if (bytesRead != s_indexEntryByteLength)
+                {
+                    throw new InvalidOperationException("Failed to read the index entry");
+                }
+
+                var entrySpan = entry.AsSpan();
+                Guid id = new(entrySpan[..s_idBytesLength]);
+                if (id.Equals(s_tombStone))
+                {
+                    continue;
+                }
+
+                if (id.Equals(Guid.Empty))
+                {
+                    break;
+                }
+
+                Span<byte> offsetBytes = entrySpan[s_idBytesLength..(s_idBytesLength + s_offsetBytesLength)];
+                Span<byte> lengthBytes = entrySpan[(s_idBytesLength + s_offsetBytesLength)..];
+                long offset = BitConverter.ToInt64(offsetBytes);
+                int length = BitConverter.ToInt32(lengthBytes);
+
+                _dataFile.Stream.Seek(offset, SeekOrigin.Begin);
+                Span<byte> bytes = stackalloc byte[length];
+                _dataFile.Stream.ReadExactly(bytes);
+                yield return new Vector(bytes);
+            }
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private (long index, long offset, int length) SearchVectorInIndex(Guid id)
+    {
+        _indexFile.Stream.Seek(0, SeekOrigin.Begin);
+
+        Span<byte> entry = stackalloc byte[s_indexEntryByteLength];
+        int bytesRead;
+        long index = 0L;
+        while ((bytesRead = _indexFile.Stream.Read(entry)) > 0)
+        {
+            if (bytesRead != s_indexEntryByteLength)
+            {
+                throw new InvalidOperationException("Failed to read the index entry");
+            }
+
+            Guid vectorId = new(entry[..s_idBytesLength]);
+            if (id == vectorId)
+            {
+                Span<byte> offsetBytes = entry[s_idBytesLength..(s_idBytesLength + s_offsetBytesLength)];
+                Span<byte> lengthBytes = entry[(s_idBytesLength + s_offsetBytesLength)..];
+                long offset = BitConverter.ToInt64(offsetBytes);
+                int length = BitConverter.ToInt32(lengthBytes);
+
+                return (index, offset, length);
+            }
+            else if (vectorId.Equals(Guid.Empty))
+            {
+                break;
+            }
+
+            ++index;
+        }
+
+        return (-1L, -1L, -1);
+    }
+
+    private class MemoryMappedFileHolder : IDisposable
+    {
+        private readonly long _capacity;
+        /// <summary>
+        /// The file handle that will cause the temporary file to be deleted when the object is disposed.
+        /// </summary>
+        private FileStream _deleteHandle;
+        private MemoryMappedFile _file;
+        private MemoryMappedViewStream _stream;
+        private bool _disposedValue;
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable. - Done by a call to Reset()
+        public MemoryMappedFileHolder(long capacity)
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable. - Done by a call to Reset()
+        {
+            _capacity = capacity;
+
+            Reset();
+        }
+
+        public MemoryMappedViewStream Stream => _stream;
+
+        public void Reset()
+        {
+            DisposeStreams();
+
+            var fileName = Path.GetRandomFileName();
+            _deleteHandle = new FileStream(fileName, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.ReadWrite | FileShare.Delete, 1, FileOptions.DeleteOnClose);
+            _file = MemoryMappedFile.CreateFromFile(fileName, FileMode.OpenOrCreate, null, _capacity);
+            _stream = _file.CreateViewStream();
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    DisposeStreams();
+                }
+
+                _disposedValue = true;
+            }
+        }
+
+        ~MemoryMappedFileHolder()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: false);
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void DisposeStreams()
+        {
+            _stream?.Dispose();
+            _file?.Dispose();
+            _deleteHandle?.Dispose();
+        }
+    }
+}

--- a/Tests/VectorDatabaseTests.cs
+++ b/Tests/VectorDatabaseTests.cs
@@ -10,6 +10,8 @@ public class VectorDatabaseTests
     [SetUp]
     public void Setup()
     {
+        _db?.Vectors?.Dispose();
+
         _db = new VectorDatabase();
     }
 


### PR DESCRIPTION
﻿## 📝 Description

Adds `MemoryMappedList`, which uses `MemoryMappedFile` to store vectors.

## 🔗 Related Issues

Relates to #13

## 💡 Additional Notes

### Benchmarks

<details>
<summary>AddBenchmarks.cs</summary>

```csharp
using BenchmarkDotNet.Attributes;
using Neighborly;

namespace Benchmarks;

[MemoryDiagnoser]
public class AddBenchmarks
{
    private static readonly List<Vector> s_vectorsSmall = Enumerable.Range(0, 100).Select(_ => RandomVectorGenerator.CreateRandomVector(1536)).ToList();

    private static readonly List<Vector> s_vectorsMedium = Enumerable.Range(0, 1_000).Select(_ => RandomVectorGenerator.CreateRandomVector(1536)).ToList();

    private static readonly List<Vector> s_vectorsLarge = Enumerable.Range(0, 10_000).Select(_ => RandomVectorGenerator.CreateRandomVector(1536)).ToList();

    [Benchmark]
    public VectorList ListAddSmall()
    {
        var list = new VectorList();
        list.AddRange(s_vectorsSmall);
        return list;
    }

    [Benchmark]
    public VectorListOld ListAddSmallOld()
    {
        var list = new VectorListOld();
        list.AddRange(s_vectorsSmall);
        return list;
    }

    [Benchmark]
    public VectorList ListAddMedium()
    {
        var list = new VectorList();
        list.AddRange(s_vectorsMedium);
        return list;
    }

    [Benchmark]
    public VectorListOld ListAddMediumOld()
    {
        var list = new VectorListOld();
        list.AddRange(s_vectorsMedium);
        return list;
    }

    [Benchmark]
    public VectorList ListAddLarge()
    {
        var list = new VectorList();
        list.AddRange(s_vectorsLarge);
        return list;
    }

    [Benchmark]
    public VectorListOld ListAddLargeOld()
    {
        var list = new VectorListOld();
        list.AddRange(s_vectorsLarge);
        return list;
    }
}

```

</details>

| Method           | Mean         | Error        | StdDev       | Gen0      | Gen1   | Allocated   |
|----------------- |-------------:|-------------:|-------------:|----------:|-------:|------------:|
| ListAddSmall     |     997.2 us |      9.80 us |      9.17 us |   14.6484 | 4.8828 |   760.13 KB |
| ListAddSmallOld  |   6,410.8 us |     65.38 us |     64.21 us |   15.6250 | 7.8125 |   797.08 KB |
| ListAddMedium    |   7,874.5 us |     42.59 us |     37.75 us |  140.6250 |      - |  7559.39 KB |
| ListAddMediumOld |  64,658.4 us |  1,181.29 us |    986.43 us |  125.0000 |      - |  7947.95 KB |
| ListAddLarge     |  98,814.9 us |    710.74 us |    593.50 us | 1500.0000 |      - | 75551.85 KB |
| ListAddLargeOld  | 636,439.3 us | 12,643.37 us | 15,051.03 us | 1000.0000 |      - | 79854.53 KB |