### PR TITLE
feat: Add OTEL with and traces metrics sample

### DIFF
--- a/API.gRPC/API.csproj
+++ b/API.gRPC/API.csproj
@@ -14,6 +14,13 @@
     <PackageReference Include="Grpc.Tools" Version="2.63.0" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup Label="OpenTelemetry">
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Neighborly\Neighborly.csproj" />
   </ItemGroup>

--- a/Neighborly.sln
+++ b/Neighborly.sln
@@ -20,6 +20,17 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "API", "API.gRPC\API.csproj"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Neighborly.Adapters.SemanticKernel", "Adapters.SemanticKernel\Neighborly.Adapters.SemanticKernel.csproj", "{9D262D2E-A3C1-40C2-8DF0-C1107DC1D999}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{F504D95A-17EC-42D4-BF51-D50F32D1909F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "OTEL", "OTEL", "{D075B534-16E4-46F8-BB54-3E8F7C91D7F8}"
+	ProjectSection(SolutionItems) = preProject
+		samples\OTEL\README.md = samples\OTEL\README.md
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IndexAPI.AppHost", "samples\OTEL\IndexAPI.AppHost\IndexAPI.AppHost.csproj", "{2DA843D3-ACC2-4138-AC55-239549AFD0E1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IndexAPI", "samples\OTEL\IndexAPI\IndexAPI.csproj", "{08DF9A7A-5C8F-4D1B-ADB7-A3375760A0CD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -42,9 +53,22 @@ Global
 		{9D262D2E-A3C1-40C2-8DF0-C1107DC1D999}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9D262D2E-A3C1-40C2-8DF0-C1107DC1D999}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9D262D2E-A3C1-40C2-8DF0-C1107DC1D999}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2DA843D3-ACC2-4138-AC55-239549AFD0E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2DA843D3-ACC2-4138-AC55-239549AFD0E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2DA843D3-ACC2-4138-AC55-239549AFD0E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2DA843D3-ACC2-4138-AC55-239549AFD0E1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{08DF9A7A-5C8F-4D1B-ADB7-A3375760A0CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{08DF9A7A-5C8F-4D1B-ADB7-A3375760A0CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{08DF9A7A-5C8F-4D1B-ADB7-A3375760A0CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{08DF9A7A-5C8F-4D1B-ADB7-A3375760A0CD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{D075B534-16E4-46F8-BB54-3E8F7C91D7F8} = {F504D95A-17EC-42D4-BF51-D50F32D1909F}
+		{2DA843D3-ACC2-4138-AC55-239549AFD0E1} = {D075B534-16E4-46F8-BB54-3E8F7C91D7F8}
+		{08DF9A7A-5C8F-4D1B-ADB7-A3375760A0CD} = {D075B534-16E4-46F8-BB54-3E8F7C91D7F8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3FFE818A-6491-46CE-84D7-B6B8DFAA0352}

--- a/Neighborly/Instrumentation.cs
+++ b/Neighborly/Instrumentation.cs
@@ -1,0 +1,56 @@
+﻿using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Neighborly;
+
+public class Instrumentation : IDisposable
+{
+    internal const string ActivitySourceName = nameof(Neighborly);
+
+    internal const string MeterName = nameof(Neighborly);
+
+    private bool _disposedValue;
+
+    public Instrumentation()
+    {
+        string? version = typeof(Instrumentation).Assembly.GetName().Version?.ToString();
+        ActivitySource = new(ActivitySourceName, version);
+        Meter = new(MeterName, version);
+    }
+
+    public Instrumentation(IMeterFactory meterFactory)
+    {
+        ArgumentNullException.ThrowIfNull(meterFactory);
+
+        string? version = typeof(Instrumentation).Assembly.GetName().Version?.ToString();
+        ActivitySource = new(ActivitySourceName, version);
+        Meter = meterFactory.Create(MeterName, version, [new("db.system", "neighborly")]);
+    }
+
+    public static Instrumentation Instance { get; } = new Instrumentation();
+
+    public ActivitySource ActivitySource { get; }
+
+    public Meter Meter { get; }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposedValue)
+        {
+            if (disposing)
+            {
+                ActivitySource.Dispose();
+                Meter.Dispose();
+            }
+
+            _disposedValue = true;
+        }
+    }
+
+    public void Dispose()
+    {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Neighborly/Neighborly.csproj
+++ b/Neighborly/Neighborly.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.InMemory" Version="0.11.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 </Project>

--- a/Tests/LoggingTests.cs
+++ b/Tests/LoggingTests.cs
@@ -13,7 +13,7 @@ public class LoggingTests
     public void Setup()
     {
         _logger = new MockLogger<VectorDatabase>();
-        _db = new VectorDatabase(_logger);
+        _db = new VectorDatabase(_logger, null);
     }
 
     [Test]

--- a/Tests/VectorDatabaseTests.cs
+++ b/Tests/VectorDatabaseTests.cs
@@ -323,7 +323,7 @@ public class VectorDatabaseTests
     {
         // Arrange
         var logger = new MockLogger<VectorDatabase>();
-        var db = new VectorDatabase(logger) {  };
+        var db = new VectorDatabase(logger, null) {  };
 
         var query = new Vector([1f, 2f, 3f]);
         var k = -1;
@@ -348,7 +348,7 @@ public class VectorDatabaseTests
     [Test]
     public void Ctor_WhenLoggerIsNull_ThrowsArgumentNullException()
     {
-        Assert.Throws<ArgumentNullException>(() => new VectorDatabase(null!));
+        Assert.Throws<ArgumentNullException>(() => new VectorDatabase(null!, null));
     }
 
 }

--- a/samples/OTEL/IndexAPI.AppHost/IndexAPI.AppHost.csproj
+++ b/samples/OTEL/IndexAPI.AppHost/IndexAPI.AppHost.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireHost>true</IsAspireHost>
+    <UserSecretsId>98b2455e-86a0-45ff-8364-d7db9bcb50e4</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\IndexAPI\IndexAPI.csproj" />
+    <ProjectReference Include="..\..\..\API.gRPC\API.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/OTEL/IndexAPI.AppHost/Program.cs
+++ b/samples/OTEL/IndexAPI.AppHost/Program.cs
@@ -1,0 +1,9 @@
+var builder = DistributedApplication.CreateBuilder(args);
+
+var db = builder.AddProject<Projects.API>("db")
+    .WithEnvironment("PROTO_GRPC", "true");
+builder.AddProject<Projects.IndexAPI>("api")
+    .WithExternalHttpEndpoints()
+    .WithReference(db);
+
+await builder.Build().RunAsync().ConfigureAwait(false);

--- a/samples/OTEL/IndexAPI.AppHost/Properties/launchSettings.json
+++ b/samples/OTEL/IndexAPI.AppHost/Properties/launchSettings.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17140;http://localhost:15177",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21156",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22161",
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15177",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19207",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20289",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
+      }
+    }
+  }
+}

--- a/samples/OTEL/IndexAPI.AppHost/appsettings.Development.json
+++ b/samples/OTEL/IndexAPI.AppHost/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/samples/OTEL/IndexAPI.AppHost/appsettings.json
+++ b/samples/OTEL/IndexAPI.AppHost/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
+    }
+  }
+}

--- a/samples/OTEL/IndexAPI/FakeEmbeddingService.cs
+++ b/samples/OTEL/IndexAPI/FakeEmbeddingService.cs
@@ -1,0 +1,40 @@
+﻿using System.Diagnostics;
+
+namespace IndexAPI;
+
+public class FakeEmbeddingService(Instrumentation instrumentation)
+{
+    private readonly Instrumentation _instrumentation = instrumentation ?? throw new ArgumentNullException(nameof(instrumentation));
+
+    public async ValueTask<float[]> GetEmbeddingsAsync(string text, CancellationToken cancellationToken = default)
+    {
+        using var activity = _instrumentation.ActivitySource.StartActivity(nameof(GetEmbeddingsAsync));
+
+        try
+        {
+            return await GetEmbeddingsImplAsync(text, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.ToString());
+            throw;
+        }
+        finally
+        {
+            activity?.Stop();
+        }
+    }
+
+    public async ValueTask<float[]> GetEmbeddingsImplAsync(string text, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return [];
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await Task.Delay(Random.Shared.Next(4_2, 1_3_3_7), cancellationToken).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+        return Enumerable.Range(0, text.Length).Select(static _ => (float)Random.Shared.NextDouble()).ToArray();
+    }
+}

--- a/samples/OTEL/IndexAPI/IndexAPI.csproj
+++ b/samples/OTEL/IndexAPI/IndexAPI.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="OpenTelemetry">
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.8.0-beta.1" />
+  </ItemGroup>
+
+  <ItemGroup Label="Protobuf">
+    <PackageReference Include="Grpc.AspNetCore" Version="2.63.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.63.0" PrivateAssets="All" />
+    <ProtoBuf Include="..\..\..\API.gRPC\Protos\Vector.proto" GrpcServices="Client" Link="Protos\greet.proto" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Neighborly\Neighborly.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/OTEL/IndexAPI/Instrumentation.cs
+++ b/samples/OTEL/IndexAPI/Instrumentation.cs
@@ -1,0 +1,38 @@
+﻿using System.Diagnostics;
+
+namespace IndexAPI;
+
+public class Instrumentation : IDisposable
+{
+    internal const string ActivitySourceName = $"{nameof(Neighborly)}.{nameof(IndexAPI)}";
+
+    private bool _disposedValue;
+
+    public Instrumentation()
+    {
+        string? version = typeof(Instrumentation).Assembly.GetName().Version?.ToString();
+        ActivitySource = new(ActivitySourceName, version);
+    }
+
+    public ActivitySource ActivitySource { get; }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposedValue)
+        {
+            if (disposing)
+            {
+                ActivitySource.Dispose();
+            }
+
+            _disposedValue = true;
+        }
+    }
+
+    public void Dispose()
+    {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+}

--- a/samples/OTEL/IndexAPI/Program.cs
+++ b/samples/OTEL/IndexAPI/Program.cs
@@ -1,0 +1,84 @@
+using Google.Protobuf;
+using Grpc.Core;
+using IndexAPI;
+using Microsoft.Extensions.Options;
+using Neighborly.API.Protos;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using static Neighborly.API.Protos.Vector;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+builder.Services.AddSingleton<FakeEmbeddingService>();
+
+builder.Services.Configure<VectorSettings>(builder.Configuration.GetSection(VectorSettings.Name));
+
+builder.Services.AddGrpcClient<VectorClient>(static (serviceProvider, options) =>
+{
+    var settings = serviceProvider.GetRequiredService<IOptions<VectorSettings>>().Value;
+    options.Address = settings.Uri;
+    options.ChannelOptionsActions.Add(static channelOptions =>
+    {
+        channelOptions.Credentials = ChannelCredentials.Insecure;
+    });
+});
+
+builder.Services.AddSingleton<Instrumentation>();
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resource => resource.AddService(serviceName: "SomeClient"))
+    .WithTracing(tracing =>
+    {
+        if (builder.Environment.IsDevelopment())
+        {
+            tracing.SetSampler(new AlwaysOnSampler());
+        }
+
+        tracing.AddSource(Instrumentation.ActivitySourceName)
+            .AddAspNetCoreInstrumentation()
+            .AddGrpcClientInstrumentation()
+            .AddGrpcClientInstrumentation();
+    })
+    .WithMetrics(metrics =>
+    {
+        metrics.AddRuntimeInstrumentation()
+            .AddAspNetCoreInstrumentation()
+            .AddHttpClientInstrumentation();
+    })
+    .UseOtlpExporter();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.MapPost("/", static async (string text, FakeEmbeddingService embeddingService, VectorClient vectorClient, CancellationToken cancellationToken) =>
+{
+    float[] embeddings = await embeddingService.GetEmbeddingsAsync(text, cancellationToken).ConfigureAwait(false);
+    Neighborly.Vector vector = new(embeddings, text);
+    ByteString bytes = ByteString.CopyFrom(vector.ToBinary());
+    VectorMessage vectorMessage = new() { Values = bytes };
+    var response = await vectorClient.AddVectorAsync(new AddVectorRequest { Vector = vectorMessage }, cancellationToken: cancellationToken).ConfigureAwait(false);
+    if (response.Success)
+    {
+        return Results.Created($"/{vector.Id}", vector);
+    }
+    else
+    {
+        return Results.BadRequest(response.Message);
+    }
+})
+.WithName("AddTextToIndex")
+.WithOpenApi();
+
+await app.RunAsync().ConfigureAwait(false);

--- a/samples/OTEL/IndexAPI/Properties/launchSettings.json
+++ b/samples/OTEL/IndexAPI/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:54542",
+      "sslPort": 44361
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5135",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7177;http://localhost:5135",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/OTEL/IndexAPI/VectorsSettings.cs
+++ b/samples/OTEL/IndexAPI/VectorsSettings.cs
@@ -1,0 +1,8 @@
+﻿namespace IndexAPI;
+
+public class VectorSettings
+{
+    public const string Name = "Vector";
+
+    public required Uri Uri { get; set; }
+}

--- a/samples/OTEL/IndexAPI/appsettings.Development.json
+++ b/samples/OTEL/IndexAPI/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/samples/OTEL/IndexAPI/appsettings.json
+++ b/samples/OTEL/IndexAPI/appsettings.json
@@ -1,0 +1,18 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "Metrics": {
+    "EnabledMetrics": {
+      "Microsoft.AspNetCore.*": true,
+      "System.*": true
+    }
+  },
+  "AllowedHosts": "*",
+  "Vector": {
+    "Uri": "http://localhost:5034"
+  }
+}

--- a/samples/OTEL/README.md
+++ b/samples/OTEL/README.md
@@ -1,0 +1,18 @@
+The IndexAPI project demonstrates how the Neighborly library can be integrated with OpenTelemetry. This project uses .NET Aspire,
+but any OpenTelemetry compatible collector can be used.
+
+## How to run
+
+Ensure that your system matches the [.NET Aspire system requirements](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/setup-tooling#container-runtime). 
+
+1. Start the Aspire App Host
+
+   ```bash
+   dotnet run --launch-profile http --project samples/OTEL/IndexAPI.AppHost/IndexAPI.AppHost.csproj 
+   ```
+
+1. Open the .NET Aspire dashboard on http://localhost:5034. You may have to use the login link from the AppHost's startup log.
+
+1. Perform some requests from http://localhost:5135/swagger/index.html
+
+1. Look at the different parts of the dashboard to see the traces, metrics, and logs that the APIs have produced.


### PR DESCRIPTION
﻿## 📝 Description

This adds a simple metric `neighborly.db.vectors.count` to report the number of vectors in the index, and `neighborly.db.index.rebuild` for the number of index rebuilds. Also adds a simple sample with .NET Aspire to showcase how metrics and logs might be used with OTEL.

## 🔗 Related Issues

Nada 😅🤷

## 💡 Additional Notes

Technically, nobody asked for this, yet. However, I think that any DBA will want some observability tools at some point in time. 

The manually added activities aren't executed right now, because the indexing thread is never started. It might be interesting to add additional metrics and activites/traces later on.
