### PR TITLE
feat: Add support for reading Parquet files in ETL

### DIFF
--- a/Tests/ETLTest.cs
+++ b/Tests/ETLTest.cs
@@ -7,7 +7,7 @@ public class ETLTest
 {
     public static IReadOnlyList<IETL> EtlImplementations =
     [
-        new Csv(), new JSON(), new JSONZ()  // HDF5 and Parquet are not implemented yet
+        new Csv(), new JSON(), new JSONZ(), new Neighborly.ETL.Parquet()  // HDF5 is not implemented yet
     ];
 
     [TestCaseSource(nameof(EtlImplementations))]


### PR DESCRIPTION
﻿## 📝 Description

Import Parquet files by using `ReadAsTableAsync`.

## 🔗 Related Issues

Fixes #44

## 💡 Additional Notes

This approach works with Neighborly's own export, as well as the Wikipedia file mentioned in https://github.com/nickna/Neighborly/issues/44#issuecomment-2161521910. In the future, it might be useful to have the field names configurable in some way, so that imports with other text names (but multiple string columns), and multiple float arrays could be imported. Right now, that's basically unsupported.

The main issue with the previous approach of using `if (data.Data is float[] d)` seems to be that it contains all values conflated to one array. The Parquet library uses some internal functions to read that in `ReadAsTableAsync`. An obvious downside of this could be the peak memory allocations.