### PR TITLE
fix(ci): Install .NET Aspire workload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,10 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '8.0.x'  
+        dotnet-version: '8.0.x'
+
+    - name: Restore workloads
+      run: dotnet workload restore
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -15,7 +15,10 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '8.x'  # Use the appropriate .NET version
+        dotnet-version: '8.x'
+
+    - name: Restore workloads
+      run: dotnet workload restore
 
     - name: Restore dependencies
       run: dotnet restore

--- a/API.gRPC/Dockerfile
+++ b/API.gRPC/Dockerfile
@@ -12,6 +12,7 @@ COPY LICENSE.txt ./
 # COPY ../README.md ./
 
 WORKDIR /app/API.gRPC
+RUN dotnet workload restore
 RUN dotnet restore
 
 # Copy the rest of the project files


### PR DESCRIPTION
﻿## 📝 Description

I accidentally broke the CI in #47. This adds `dotnet workload restore` to the build scripts, so that the necessary .NET Aspire workload gets installed.

## 🔗 Related Issues

None

## 💡 Additional Notes

Another option to solve the issue would be to have the samples in a separate SLN, which is not built in in CI workflow. One downside of that would be that samples could break due to API changes in other projects.