### PR TITLE
fix: `MemoryMappedList.Add(vector)` after other operations uses correct position

### DIFF
--- a/Neighborly/MemoryMappedList.cs
+++ b/Neighborly/MemoryMappedList.cs
@@ -1,5 +1,4 @@
 using Microsoft.Win32.SafeHandles;
-using Serilog.Core;
 using System.Collections;
 using System.IO.MemoryMappedFiles;
 using System.Runtime.InteropServices;
@@ -18,6 +17,11 @@ public class MemoryMappedList : IDisposable, IEnumerable<Vector>
     private readonly MemoryMappedFileHolder _dataFile;
     private readonly object _mutex = new();
     private long _count;
+    /// <summary>
+    /// Indicates if the index stream is at the end of the stream.
+    /// This is used to enable fast adding of multiple vectors in sequence.
+    /// </summary>
+    private bool _isAtEndOfIndexStream = true;
     private bool _disposedValue;
     private long _defragPosition = 0; // Tracks the current position in the index file for defragmentation
     private long _defragIndexPosition;
@@ -78,9 +82,9 @@ public class MemoryMappedList : IDisposable, IEnumerable<Vector>
         // Only run this function on Windows
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) == false)
         {
-            return; 
+            return;
         }
- 
+
         // Create a sparse file
         SafeFileHandle fileHandle = CreateFile(
             path,
@@ -174,6 +178,10 @@ public class MemoryMappedList : IDisposable, IEnumerable<Vector>
             Span<byte> lengthBytes = entry[(s_idBytesLength + s_offsetBytesLength)..];
             long offset = BitConverter.ToInt64(offsetBytes);
             int length = BitConverter.ToInt32(lengthBytes);
+            if (offset < 0L || length <= 0)
+            {
+                return null;
+            }
 
             _dataFile.Stream.Seek(offset, SeekOrigin.Begin);
             Span<byte> bytes = stackalloc byte[length];
@@ -187,7 +195,7 @@ public class MemoryMappedList : IDisposable, IEnumerable<Vector>
         lock (_mutex)
         {
             (_, long offset, int length) = SearchVectorInIndex(id);
-            if (offset < 0L || length < 0L)
+            if (offset < 0L || length <= 0)
             {
                 return null;
             }
@@ -252,6 +260,11 @@ public class MemoryMappedList : IDisposable, IEnumerable<Vector>
         lock (_mutex)
         {
             Span<byte> entry = stackalloc byte[s_indexEntryByteLength];
+            if (!_isAtEndOfIndexStream)
+            {
+                ReadToEnd();
+            }
+
             Span<byte> idBytes = entry[..s_idBytesLength];
             if (!vector.Id.TryWriteBytes(idBytes))
             {
@@ -275,6 +288,7 @@ public class MemoryMappedList : IDisposable, IEnumerable<Vector>
             _dataFile.Stream.Write(data);
 
             ++_count;
+            _isAtEndOfIndexStream = true;
         }
     }
 
@@ -284,6 +298,7 @@ public class MemoryMappedList : IDisposable, IEnumerable<Vector>
 
         lock (_mutex)
         {
+            _isAtEndOfIndexStream = false;
             _indexFile.Stream.Seek(0, SeekOrigin.Begin);
 
             Span<byte> entry = stackalloc byte[s_indexEntryByteLength];
@@ -299,7 +314,7 @@ public class MemoryMappedList : IDisposable, IEnumerable<Vector>
                 if (id == vector.Id)
                 {
                     // Seek to the beginning of the entry and remove the ID with a tombstone-ID
-                    _indexFile.Stream.Seek(-s_indexEntryByteLength, SeekOrigin.Current);
+                    ReverseIndexStreamByIdBytesLength();
                     _indexFile.Stream.Write(s_tombStoneBytes);
                     // Seek to after the entry
                     _indexFile.Stream.Seek(s_indexEntryByteLength - s_idBytesLength, SeekOrigin.Current);
@@ -308,6 +323,8 @@ public class MemoryMappedList : IDisposable, IEnumerable<Vector>
                 }
                 else if (id.Equals(Guid.Empty))
                 {
+                    _isAtEndOfIndexStream = true;
+                    ReverseIndexStreamByIdBytesLength();
                     break;
                 }
             }
@@ -556,6 +573,7 @@ public class MemoryMappedList : IDisposable, IEnumerable<Vector>
     {
         lock (_mutex)
         {
+            _isAtEndOfIndexStream = false;
             _indexFile.Stream.Seek(0, SeekOrigin.Begin);
             _dataFile.Stream.Seek(0, SeekOrigin.Begin);
 
@@ -577,6 +595,8 @@ public class MemoryMappedList : IDisposable, IEnumerable<Vector>
 
                 if (id.Equals(Guid.Empty))
                 {
+                    _isAtEndOfIndexStream = true;
+                    ReverseIndexStreamByIdBytesLength();
                     break;
                 }
 
@@ -597,6 +617,7 @@ public class MemoryMappedList : IDisposable, IEnumerable<Vector>
 
     private (long index, long offset, int length) SearchVectorInIndex(Guid id)
     {
+        _isAtEndOfIndexStream = false;
         _indexFile.Stream.Seek(0, SeekOrigin.Begin);
 
         Span<byte> entry = stackalloc byte[s_indexEntryByteLength];
@@ -621,6 +642,8 @@ public class MemoryMappedList : IDisposable, IEnumerable<Vector>
             }
             else if (vectorId.Equals(Guid.Empty))
             {
+                _isAtEndOfIndexStream = true;
+                ReverseIndexStreamByIdBytesLength();
                 break;
             }
 
@@ -628,6 +651,66 @@ public class MemoryMappedList : IDisposable, IEnumerable<Vector>
         }
 
         return (-1L, -1L, -1);
+    }
+
+    /// <summary>
+    /// Reads the index file and the data file to the last entry,
+    /// so that new data can be appended safely.
+    /// </summary>
+    private void ReadToEnd()
+    {
+        _indexFile.Stream.Seek(0, SeekOrigin.Begin);
+
+        // To keep track of the current position in the data file
+        // that we can use to append new data.
+        // Theoretically, this should always be the last records offset + length,
+        // but we can't be sure that the index file is always in sync with the data file.
+        long maxOffset = -1L;
+        int lengthAtMaxOffset = -1;
+
+        Span<byte> entry = stackalloc byte[s_indexEntryByteLength];
+        int bytesRead;
+        while ((bytesRead = _indexFile.Stream.Read(entry)) > 0)
+        {
+            if (bytesRead != s_indexEntryByteLength)
+            {
+                throw new InvalidOperationException("Failed to read the index entry");
+            }
+
+            Guid vectorId = new(entry[..s_idBytesLength]);
+            if (!vectorId.Equals(Guid.Empty))
+            {
+                Span<byte> offsetBytes = entry[s_idBytesLength..(s_idBytesLength + s_offsetBytesLength)];
+                Span<byte> lengthBytes = entry[(s_idBytesLength + s_offsetBytesLength)..];
+                long offset = BitConverter.ToInt64(offsetBytes);
+                int length = BitConverter.ToInt32(lengthBytes);
+
+                if (offset > maxOffset || (offset == maxOffset && length > lengthAtMaxOffset))
+                {
+                    maxOffset = offset;
+                    lengthAtMaxOffset = length;
+                }
+            }
+            else
+            {
+                _isAtEndOfIndexStream = true;
+                ReverseIndexStreamByIdBytesLength();
+                _dataFile.Stream.Seek(maxOffset + lengthAtMaxOffset, SeekOrigin.Begin);
+                break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// If the index stream is not at the beginning, it will be moved to the previous entry.
+    /// This is to go back one entry after searching for an entry and getting an empty entry.
+    /// </summary>
+    private void ReverseIndexStreamByIdBytesLength()
+    {
+        if (_indexFile.Stream.Position != 0L)
+        {
+            _indexFile.Stream.Seek(-s_indexEntryByteLength, SeekOrigin.Current);
+        }
     }
 
     private class MemoryMappedFileHolder : IDisposable
@@ -653,7 +736,7 @@ public class MemoryMappedList : IDisposable, IEnumerable<Vector>
         {
             DisposeStreams();
 
-            _fileName= Path.GetTempFileName();
+            _fileName = Path.GetTempFileName();
             _WinFileAlloc(_fileName);
             double capacityTiB = _capacity / (1024.0 * 1024.0 * 1024.0 * 1024.0);
             Logging.Logger.Information("Creating temporary file: {FileName}, size {capacity} TiB", _fileName, capacityTiB);

--- a/Tests/MemoryMappedFileTests.cs
+++ b/Tests/MemoryMappedFileTests.cs
@@ -226,6 +226,22 @@ namespace Tests
             Assert.That(stopwatch.Elapsed, Is.LessThan(maxAcceptableTime), $"Defragmentation should complete within {maxAcceptableTime.TotalSeconds} seconds.");
         }
 
+        [Test]
+        public void AddWhenCalledAfterAnEnumerationWorks()
+        {
+            // Arrange
+            var vector1 = new Vector(new float[] { 1, 2, 3 });
+            var vector2 = new Vector(new float[] { 4, 5, 6 });
+            _db.Vectors.Add(vector1);
+
+            // Act
+            _ = _db.Vectors.Find(v => v.Id == Guid.NewGuid());
+            _db.Vectors.Add(vector2);
+
+            // Assert
+            Assert.That(_db.Vectors.Contains(vector1), Is.True, "Database should contain vector1.");
+            Assert.That(_db.Vectors.Contains(vector2), Is.True, "Database should contain vector2.");
+        }
 
     }
 }


### PR DESCRIPTION
﻿## 📝 Description

`MemoryMappedList.Add(vector)` always assumed the underlying `Stream`s to be at the correct position. There could be several cases where this was false, for example after performing LINQ operations on the `MemoryMappedList`.

## 🔗 Related Issues

Nada

## 💡 Additional Notes

I used the `develop` branch as the base, so that I had a place to put the test method in. Theoretically, this could also be done by just cherry-picking e4cb4232313898b87d9a86fe9adddec3e6e28337 to `master`.
