### PR TITLE
fix: Fix bug in `Vector.ToBinary()` method

### DIFF
--- a/Neighborly/Vector.cs
+++ b/Neighborly/Vector.cs
@@ -395,9 +395,9 @@ public partial class Vector : IEquatable<Vector>
         }
 
         Span<byte> originalTextLengthBytes = result[s_originalTextLengthOffset..(s_originalTextLengthOffset + s_originalTextLengthBytesLength)];
-        if (!BitConverter.TryWriteBytes(originalTextLengthBytes, OriginalText.Length))
+        if (!BitConverter.TryWriteBytes(originalTextLengthBytes, originalTextBytesLength))
         {
-            throw new InvalidOperationException("Failed to write OriginalText.Length to bytes");
+            throw new InvalidOperationException("Failed to write originalTextBytesLength to bytes");
         }
 
         Span<byte> originalTextBytes = result[s_originalTextOffset..(s_originalTextOffset + originalTextBytesLength)];

--- a/Tests/ETLTest.cs
+++ b/Tests/ETLTest.cs
@@ -1,6 +1,6 @@
 ﻿using Neighborly.ETL;
 
-namespace Neighborly.Tests.ETL;
+namespace Neighborly.Tests;
 
 [TestFixture]
 public class ETLTest

--- a/Tests/VectorTests.cs
+++ b/Tests/VectorTests.cs
@@ -1,14 +1,27 @@
+namespace Neighborly.Tests;
+
 using Neighborly;
 
 [TestFixture]
 public class VectorTests
 {
+    private static readonly string[] s_originalTexts = [
+        "The quick brown fox jumps over the lazy dog", // English
+        "素早い茶色の狐が怠け者の犬を飛び越える", // Japanese
+        "Le vif renard brun saute par-dessus le chien paresseux", // French
+        "El rápido zorro marrón salta sobre el perro perezoso", // Spanish
+        "Быстрая коричневая лисица перепрыгивает через ленивую собаку", // Russian
+        "الثعلب البني السريع يقفز فوق الكلب الكسول", // Arabic (RTL)
+        "快速的棕色狐狸跳过了懒狗", // Chinese (Simplified)
+        "השועל החום המהיר קופץ מעל הכלב העצלן" // Hebrew (RTL)
+    ];
+
     [Test]
-    public void ToBinary_CanBeUsedAsInputFor_Ctor_As_BinaryReader()
+    public void ToBinary_CanBeUsedAsInputFor_Ctor_As_BinaryReader([ValueSource(nameof(s_originalTexts))] string originalText)
     {
         // Arrange
         float[] floatArray = [1.0f, 2.1f, 3.2f, 4.5f, 5.7f];
-        Vector originalVector = new(floatArray, "Test");
+        Vector originalVector = new(floatArray, originalText);
 
         // Act
         byte[] binary = originalVector.ToBinary();
@@ -26,11 +39,11 @@ public class VectorTests
     }
 
     [Test]
-    public void ToBinary_CanBeUsedAsInputFor_Ctor_As_Array()
+    public void ToBinary_CanBeUsedAsInputFor_Ctor_As_Array([ValueSource(nameof(s_originalTexts))] string originalText)
     {
         // Arrange
         float[] floatArray = [1.0f, 2.1f, 3.2f, 4.5f, 5.7f];
-        Vector originalVector = new(floatArray, "Test");
+        Vector originalVector = new(floatArray, originalText);
 
         // Act
         byte[] binary = originalVector.ToBinary();


### PR DESCRIPTION
﻿## 📝 Description

Uses the correct text length for the binary representation of the vector. Also adds some test cases for separate scripts.

The code did not work with multi-byte characters, just with ASCII and similar single-byte encoded values. 

## 🔗 Related Issues

None

## 💡 Additional Notes

This is my bad. I should have used better test cases from the get go.