### PR TITLE
docs: Add a Semantic Kernel sample

### DIFF
--- a/API.gRPC/API.csproj
+++ b/API.gRPC/API.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.62.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.63.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0-Preview.1" />
     <PackageReference Include="Grpc.Tools" Version="2.63.0" PrivateAssets="All" />
   </ItemGroup>

--- a/Adapters.SemanticKernel/Neighborly.Adapters.SemanticKernel.csproj
+++ b/Adapters.SemanticKernel/Neighborly.Adapters.SemanticKernel.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.13.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.13.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.13.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.13.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.PromptTemplates.Handlebars" Version="1.13.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Yaml" Version="1.13.0" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.14.1" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.14.1" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.14.1" />
+    <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.14.1" />
+    <PackageReference Include="Microsoft.SemanticKernel.PromptTemplates.Handlebars" Version="1.14.1" />
+    <PackageReference Include="Microsoft.SemanticKernel.Yaml" Version="1.14.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="System.Numerics.Tensors" Version="8.0.0" />
   </ItemGroup>

--- a/Neighborly.sln
+++ b/Neighborly.sln
@@ -31,6 +31,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IndexAPI.AppHost", "samples
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IndexAPI", "samples\OTEL\IndexAPI\IndexAPI.csproj", "{08DF9A7A-5C8F-4D1B-ADB7-A3375760A0CD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SemanticKernel", "samples\SemanticKernel\SemanticKernel.csproj", "{77C06B8E-264D-4B49-8F74-0FF80E8C12DA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -61,6 +63,10 @@ Global
 		{08DF9A7A-5C8F-4D1B-ADB7-A3375760A0CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{08DF9A7A-5C8F-4D1B-ADB7-A3375760A0CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{08DF9A7A-5C8F-4D1B-ADB7-A3375760A0CD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{77C06B8E-264D-4B49-8F74-0FF80E8C12DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{77C06B8E-264D-4B49-8F74-0FF80E8C12DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{77C06B8E-264D-4B49-8F74-0FF80E8C12DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{77C06B8E-264D-4B49-8F74-0FF80E8C12DA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -69,6 +75,7 @@ Global
 		{D075B534-16E4-46F8-BB54-3E8F7C91D7F8} = {F504D95A-17EC-42D4-BF51-D50F32D1909F}
 		{2DA843D3-ACC2-4138-AC55-239549AFD0E1} = {D075B534-16E4-46F8-BB54-3E8F7C91D7F8}
 		{08DF9A7A-5C8F-4D1B-ADB7-A3375760A0CD} = {D075B534-16E4-46F8-BB54-3E8F7C91D7F8}
+		{77C06B8E-264D-4B49-8F74-0FF80E8C12DA} = {F504D95A-17EC-42D4-BF51-D50F32D1909F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3FFE818A-6491-46CE-84D7-B6B8DFAA0352}

--- a/Neighborly/Vector.cs
+++ b/Neighborly/Vector.cs
@@ -395,9 +395,9 @@ public partial class Vector : IEquatable<Vector>
         }
 
         Span<byte> originalTextLengthBytes = result[s_originalTextLengthOffset..(s_originalTextLengthOffset + s_originalTextLengthBytesLength)];
-        if (!BitConverter.TryWriteBytes(originalTextLengthBytes, OriginalText.Length))
+        if (!BitConverter.TryWriteBytes(originalTextLengthBytes, originalTextBytesLength))
         {
-            throw new InvalidOperationException("Failed to write OriginalText.Length to bytes");
+            throw new InvalidOperationException("Failed to write originalTextBytesLength to bytes");
         }
 
         Span<byte> originalTextBytes = result[s_originalTextOffset..(s_originalTextOffset + originalTextBytesLength)];

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Neighborly offers a range of advanced search algorithms to efficiently query vec
 We welcome contributions! If you have ideas for new features or have found bugs, please open an issue or submit a pull request. For major changes, please discuss them in an issue first.
 
 # License
-This project is licensed under the MIT License. See the LICENSE file for details.
+This project is licensed under the MIT License. See the [LICENSE](LICENSE.txt) file for details.
 
 # Contact
 For any questions or further assistance, feel free to contact [![GitHub](https://img.shields.io/badge/GitHub-nickna-blue)](https://github.com/nickna).

--- a/Tests/ETLTest.cs
+++ b/Tests/ETLTest.cs
@@ -1,6 +1,6 @@
 ﻿using Neighborly.ETL;
 
-namespace Neighborly.Tests.ETL;
+namespace Neighborly.Tests;
 
 [TestFixture]
 public class ETLTest

--- a/Tests/VectorTests.cs
+++ b/Tests/VectorTests.cs
@@ -1,14 +1,27 @@
+namespace Neighborly.Tests;
+
 using Neighborly;
 
 [TestFixture]
 public class VectorTests
 {
+    private static readonly string[] s_originalTexts = [
+        "The quick brown fox jumps over the lazy dog", // English
+        "素早い茶色の狐が怠け者の犬を飛び越える", // Japanese
+        "Le vif renard brun saute par-dessus le chien paresseux", // French
+        "El rápido zorro marrón salta sobre el perro perezoso", // Spanish
+        "Быстрая коричневая лисица перепрыгивает через ленивую собаку", // Russian
+        "الثعلب البني السريع يقفز فوق الكلب الكسول", // Arabic (RTL)
+        "快速的棕色狐狸跳过了懒狗", // Chinese (Simplified)
+        "השועל החום המהיר קופץ מעל הכלב העצלן" // Hebrew (RTL)
+    ];
+
     [Test]
-    public void ToBinary_CanBeUsedAsInputFor_Ctor_As_BinaryReader()
+    public void ToBinary_CanBeUsedAsInputFor_Ctor_As_BinaryReader([ValueSource(nameof(s_originalTexts))] string originalText)
     {
         // Arrange
         float[] floatArray = [1.0f, 2.1f, 3.2f, 4.5f, 5.7f];
-        Vector originalVector = new(floatArray, "Test");
+        Vector originalVector = new(floatArray, originalText);
 
         // Act
         byte[] binary = originalVector.ToBinary();
@@ -26,11 +39,11 @@ public class VectorTests
     }
 
     [Test]
-    public void ToBinary_CanBeUsedAsInputFor_Ctor_As_Array()
+    public void ToBinary_CanBeUsedAsInputFor_Ctor_As_Array([ValueSource(nameof(s_originalTexts))] string originalText)
     {
         // Arrange
         float[] floatArray = [1.0f, 2.1f, 3.2f, 4.5f, 5.7f];
-        Vector originalVector = new(floatArray, "Test");
+        Vector originalVector = new(floatArray, originalText);
 
         // Act
         byte[] binary = originalVector.ToBinary();

--- a/samples/OTEL/IndexAPI/IndexAPI.csproj
+++ b/samples/OTEL/IndexAPI/IndexAPI.csproj
@@ -23,7 +23,7 @@
   <ItemGroup Label="Protobuf">
     <PackageReference Include="Grpc.AspNetCore" Version="2.63.0" />
     <PackageReference Include="Grpc.Tools" Version="2.63.0" PrivateAssets="All" />
-    <ProtoBuf Include="..\..\..\API.gRPC\Protos\Vector.proto" GrpcServices="Client" Link="Protos\greet.proto" />
+    <ProtoBuf Include="..\..\..\API.gRPC\Protos\Vector.proto" GrpcServices="Client" Link="Protos\Vector.proto" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/SemanticKernel/Ballad.txt
+++ b/samples/SemanticKernel/Ballad.txt
@@ -1,0 +1,39 @@
+Wer reitet so spät durch Nacht und Wind?
+Es ist der Vater mit seinem Kind;
+Er hat den Knaben wohl in dem Arm,
+Er fasst ihn sicher, er hält ihn warm.
+
+Mein Sohn, was birgst du so bang dein Gesicht? –
+Siehst, Vater, du den Erlkönig nicht?
+Den Erlenkönig mit Kron’ und Schweif? –
+Mein Sohn, es ist ein Nebelstreif. –
+
+„Du liebes Kind, komm, geh mit mir!
+Gar schöne Spiele spiel’ ich mit dir;
+Manch’ bunte Blumen sind an dem Strand,
+Meine Mutter hat manch gülden Gewand.“ –
+
+Mein Vater, mein Vater, und hörest du nicht,
+Was Erlenkönig mir leise verspricht? –
+Sei ruhig, bleibe ruhig, mein Kind;
+In dürren Blättern säuselt der Wind. –
+
+„Willst, feiner Knabe, du mit mir gehn?
+Meine Töchter sollen dich warten schön;
+Meine Töchter führen den nächtlichen Reihn
+Und wiegen und tanzen und singen dich ein.“ –
+
+Mein Vater, mein Vater, und siehst du nicht dort
+Erlkönigs Töchter am düstern Ort? –
+Mein Sohn, mein Sohn, ich seh’ es genau:
+Es scheinen die alten Weiden so grau. –
+
+„Ich liebe dich, mich reizt deine schöne Gestalt;
+Und bist du nicht willig, so brauch’ ich Gewalt.“ –
+Mein Vater, mein Vater, jetzt fasst er mich an!
+Erlkönig hat mir ein Leids getan! –
+
+Dem Vater grauset’s; er reitet geschwind,
+Er hält in den Armen das ächzende Kind,
+Erreicht den Hof mit Mühe und Not;
+In seinen Armen das Kind war tot. 

--- a/samples/SemanticKernel/Ballad.txt
+++ b/samples/SemanticKernel/Ballad.txt
@@ -1,39 +1,37 @@
-Wer reitet so spät durch Nacht und Wind?
-Es ist der Vater mit seinem Kind;
-Er hat den Knaben wohl in dem Arm,
-Er fasst ihn sicher, er hält ihn warm.
+In the realm of data, vast and wide,
+Where numbers dance and can't decide,
+There lies a place, quite orderly,
+A vector database named Neighborly.
 
-Mein Sohn, was birgst du so bang dein Gesicht? –
-Siehst, Vater, du den Erlkönig nicht?
-Den Erlenkönig mit Kron’ und Schweif? –
-Mein Sohn, es ist ein Nebelstreif. –
+**Chorus:**
+Oh, Neighborly, with queries so fast,
+In the land of data, you're unsurpassed.
+Your indexes, like stars, align so free,
+In the digital cosmos of Neighborly.
 
-„Du liebes Kind, komm, geh mit mir!
-Gar schöne Spiele spiel’ ich mit dir;
-Manch’ bunte Blumen sind an dem Strand,
-Meine Mutter hat manch gülden Gewand.“ –
+With algorithms sharp as a smith's own blade,
+It sorts through vectors that users have made.
+Each point in space, a node to see,
+In the structured haven of Neighborly.
 
-Mein Vater, mein Vater, und hörest du nicht,
-Was Erlenkönig mir leise verspricht? –
-Sei ruhig, bleibe ruhig, mein Kind;
-In dürren Blättern säuselt der Wind. –
+**Chorus:**
+Oh, Neighborly, with searches so true,
+You find the nearest neighbor to pursue.
+Your storage vast, as deep as the sea,
+In the boundless vaults of Neighborly.
 
-„Willst, feiner Knabe, du mit mir gehn?
-Meine Töchter sollen dich warten schön;
-Meine Töchter führen den nächtlichen Reihn
-Und wiegen und tanzen und singen dich ein.“ –
+It scales the peaks of data's mount,
+Drinks from the binary data fount.
+Efficient, swift, it works with glee,
+This marvel known as Neighborly.
 
-Mein Vater, mein Vater, und siehst du nicht dort
-Erlkönigs Töchter am düstern Ort? –
-Mein Sohn, mein Sohn, ich seh’ es genau:
-Es scheinen die alten Weiden so grau. –
+**Chorus:**
+Oh, Neighborly, your clusters shine,
+With every search, they realign.
+A beacon of data's harmony,
+That's the magic of Neighborly.
 
-„Ich liebe dich, mich reizt deine schöne Gestalt;
-Und bist du nicht willig, so brauch’ ich Gewalt.“ –
-Mein Vater, mein Vater, jetzt fasst er mich an!
-Erlkönig hat mir ein Leids getan! –
-
-Dem Vater grauset’s; er reitet geschwind,
-Er hält in den Armen das ächzende Kind,
-Erreicht den Hof mit Mühe und Not;
-In seinen Armen das Kind war tot. 
+So here's to you, oh database,
+Your speedy search, none can outpace.
+In bytes and bits, you hold the key,
+To a world more connected, thanks to Neighborly.

--- a/samples/SemanticKernel/Dockerfile
+++ b/samples/SemanticKernel/Dockerfile
@@ -1,0 +1,5 @@
+FROM ollama/ollama:0.1.44
+
+ARG MODEL_NAME=phi3
+ARG EMBEDDING_MODEL_NAME=all-minilm
+RUN nohup bash -c "ollama serve &" && sleep 5 && ollama pull "$MODEL_NAME" && ollama pull "$EMBEDDING_MODEL_NAME"

--- a/samples/SemanticKernel/LOTR.txt
+++ b/samples/SemanticKernel/LOTR.txt
@@ -1,0 +1,24 @@
+In the land of Middle-earth, 'neath the sky so wide,
+Two wizards walked in wisdom, side by side.
+Gandalf the Grey, with his staff held high,
+Saruman the White, with a gleam in his eye.
+
+They delved in deep lore, in the ancient halls,
+Their voices echoed through Isengard's walls.
+Once brothers in magic, in purpose aligned,
+Till the lure of the ring made Saruman blind.
+
+But imagine a tale where love conquers all,
+Where Gandalf's compassion breaks down the wall.
+In the golden wood, 'neath the mallorn trees,
+They find a love as deep as the Sundering Seas.
+
+Saruman's heart, once cold and misled,
+Is warmed by Gandalf's touch, and the words unsaid.
+Together they stand, against shadow and flame,
+United in love, in more than just name.
+
+So sing of the wizards, whose fates intertwine,
+In a world where love's magic is truly divine.
+For even the wise can learn something new,
+When love is the lesson, and the heart is true.

--- a/samples/SemanticKernel/Program.cs
+++ b/samples/SemanticKernel/Program.cs
@@ -1,0 +1,134 @@
+﻿using Atc.SemanticKernel.Connectors.Ollama;
+using Atc.SemanticKernel.Connectors.Ollama.ChatCompletion;
+using Atc.SemanticKernel.Connectors.Ollama.Extensions;
+using Atc.SemanticKernel.Connectors.Ollama.TextEmbeddingGeneration;
+using Atc.SemanticKernel.Connectors.Ollama.TextGenerationService;
+using NeighborlyMemory;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
+using Microsoft.SemanticKernel.Plugins.Memory;
+using DotNet.Testcontainers.Builders;
+using Microsoft.SemanticKernel.Embeddings;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.TextGeneration;
+
+const string modelName = "phi3";
+const string embeddingModelName = "all-minilm";
+
+// Start local ollama instance
+var ollama = new ContainerBuilder()
+    .WithImage("ollama/ollama:latest")
+    .WithPortBinding(11434, true)
+    .Build();
+
+await ollama.StartAsync().ConfigureAwait(false);
+
+Uri ollamaUri = new Uri($"http://localhost:{ollama.GetMappedPublicPort(11434)}");
+
+await ollama.ExecAsync(["ollama", "pull", modelName]).ConfigureAwait(false);
+await ollama.ExecAsync(["ollama", "pull", embeddingModelName]).ConfigureAwait(false);
+
+OllamaChatCompletionService ollamaChat = new(ollamaUri, modelName);
+OllamaTextGenerationService ollamaText = new(ollamaUri, modelName);
+OllamaTextEmbeddingGenerationService ollamaEmbedding = new(ollamaUri, embeddingModelName);
+
+#pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable SKEXP0050 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+var memory = new MemoryBuilder()
+    .WithMemoryStore(new NeighborlyMemoryStore(new Neighborly.VectorDatabase())) // Use NeighborlyMemoryStore
+    .WithTextEmbeddingGeneration(ollamaEmbedding)
+    .Build();
+#pragma warning restore SKEXP0050 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+// semantic kernel builder
+var builder = Kernel.CreateBuilder();
+builder.Services.AddSingleton<IChatCompletionService>(ollamaChat);
+builder.Services.AddSingleton<ITextGenerationService>(ollamaText);
+#pragma warning disable SKEXP0001
+builder.Services.AddSingleton<ITextEmbeddingGenerationService>(ollamaEmbedding);
+#pragma warning restore SKEXP0001
+
+var kernel = builder.Build();
+
+#pragma warning disable SKEXP0050 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+var memoryPlugin = kernel.ImportPluginFromObject(new TextMemoryPlugin(memory));
+#pragma warning restore SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore SKEXP0050 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+/*Console.WriteLine("====================");
+Console.WriteLine("CHAT COMPLETION DEMO");
+Console.WriteLine("====================");
+var chatCompletionService = kernel.GetRequiredService<IChatCompletionService>();
+var history = new ChatHistory();
+history.AddSystemMessage("You are a useful assistant that replies with short messages.");
+Console.WriteLine("Hint: type your question or type 'exit' to leave the conversation");
+Console.WriteLine();
+
+// Chat loop
+while (true)
+{
+    Console.Write("You: ");
+    var input = Console.ReadLine();
+
+    if (string.IsNullOrEmpty(input) ||
+        input.Equals("exit", StringComparison.OrdinalIgnoreCase))
+    {
+        break;
+    }
+
+    history.AddUserMessage(input);
+    var chatResponse = await chatCompletionService.GetChatMessageContentsAsync(history);
+
+    Console.WriteLine(chatResponse[^1].Content);
+    Console.WriteLine("---");
+}*/
+
+Console.WriteLine("====================");
+Console.WriteLine("EMBEDDING DEMO");
+Console.WriteLine("====================");
+
+string[] texts = await File.ReadAllLinesAsync("Ballad.txt").ConfigureAwait(false);
+
+#pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable SKEXP0050 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+await kernel.InvokeAsync(memoryPlugin["Save"], new()
+{
+    [TextMemoryPlugin.InputParam] = texts,
+    [TextMemoryPlugin.CollectionParam] = "ballads",
+    [TextMemoryPlugin.KeyParam] = "info5",
+});
+#pragma warning restore SKEXP0050 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+const string RecallFunctionDefinition = @"
+Consider only the facts below when answering questions:
+
+BEGIN FACTS
+About me: {{recall 'live in Seattle?'}}
+About me: {{recall 'my family is from?'}}
+END FACTS
+
+Question: {{$input}}
+
+Answer:
+";
+#pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable SKEXP0050 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+var result = await kernel.InvokePromptAsync(RecallFunctionDefinition, new(new OpenAIPromptExecutionSettings { MaxTokens = 1000 })
+{
+    [TextMemoryPlugin.InputParam] = "Where are my family from?",
+    [TextMemoryPlugin.CollectionParam] = "ballads",
+    [TextMemoryPlugin.LimitParam] = "2",
+    [TextMemoryPlugin.RelevanceParam] = "0.79",
+});
+#pragma warning restore SKEXP0050 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+Console.WriteLine("Ask: Where are my family from?");
+Console.WriteLine($"Answer: {result.GetValue<string>()}");
+
+Console.ReadLine();

--- a/samples/SemanticKernel/README.md
+++ b/samples/SemanticKernel/README.md
@@ -37,13 +37,14 @@ To run the Semantic Kernel program, follow these steps:
 2. Build and run the program using your preferred C# development environment or the command line.
 3. The program will build a custom Ollama container image with custom models. **This will take a while on the first start.**
 4. The program will start the Ollama instance and perform the necessary setup.
-5. It will import the text from `Ballad.txt` into the Neighborly vector database.
-6. It will then prompt you to enter a question.
-7. Enter your question and press Enter.
-8. The program will retrieve the answer from the Semantic Kernel and display it.
+5. It will import the text from `Ballad.txt` and `LOTR.txt` into the Neighborly vector database.
+6. It will then prompt the LLM two predfined questions.
+7. The program will retrieve the answer from the Semantic Kernel and display it.
 
 That's it! You have successfully run the Semantic Kernel sample and used `Neighborly.Adapters.SemanticKernel` as the `ISemanticTextMemory` for SemanticKernel with Ollama.
 
 # License
 
 This project is licensed under the MIT License. See the [LICENSE](../../LICENSE.txt) file for details. The sample was adapted from the excellent [Atc.SemanticKernel.Console.Sample](https://github.com/atc-net/atc-semantic-kernel/blob/3adb10d5f5e3c099ce999bbbd5aa4a972073e7f6/sample/Atc.SemanticKernel.Console.Sample/Program.cs) Copyright (c) 2024 [atc-net](https://atc-net.github.io/), which is also licensed under the MIT License.
+
+All ballads were made up by Bing Chat/GPT 4.

--- a/samples/SemanticKernel/README.md
+++ b/samples/SemanticKernel/README.md
@@ -1,0 +1,49 @@
+## Dependencies
+
+To run the Semantic Kernel sample, you will need the following dependencies:
+
+- Docker: Make sure Docker is installed on your machine.
+
+## Getting Started
+
+1. Clone the Neighborly repository to your local machine.
+2. Navigate to the `samples/SemanticKernel` directory.
+3. Open the `Program.cs` file.
+
+## Program Overview
+
+The Semantic Kernel sample demonstrates how to use the `Neighborly.Adapters.SemanticKernel` library as a text memory for [Semantic Kernel](https://aka.ms/semantic-kernel) with [Ollama](https://ollama.com/) as the language model. It provides an end-to-end example of using the vector database with.
+
+The program performs the following steps:
+
+1. Imports the necessary namespaces and libraries.
+2. Defines the model and embedding names.
+3. Creates a custom Ollama image from the [Dockerfile](Dockerfile) using the `ImageFromDockerfileBuilder` class.
+4. Starts a local Ollama instance using the `ContainerBuilder` class.
+5. Initializes the OLLAMA services for chat completion, text generation, and text embedding generation.
+6. Sets up the Neighborly vector database and memory store.
+7. Builds the Semantic Kernel using the `Kernel.CreateBuilder()` method.
+8. Registers the necessary services for the Semantic Kernel.
+9. Builds the kernel.
+10. Saves a text file to the memory using the memory plugin.
+11. Rebuilds the search indexes.
+12. Prompts a question to the kernel and retrieves the answer.
+
+## How to run
+
+To run the Semantic Kernel program, follow these steps:
+
+1. Make sure Docker is running on your machine.
+2. Build and run the program using your preferred C# development environment or the command line.
+3. The program will build a custom Ollama container image with custom models. **This will take a while on the first start.**
+4. The program will start the Ollama instance and perform the necessary setup.
+5. It will import the text from `Ballad.txt` into the Neighborly vector database.
+6. It will then prompt you to enter a question.
+7. Enter your question and press Enter.
+8. The program will retrieve the answer from the Semantic Kernel and display it.
+
+That's it! You have successfully run the Semantic Kernel sample and used `Neighborly.Adapters.SemanticKernel` as the `ISemanticTextMemory` for SemanticKernel with Ollama.
+
+# License
+
+This project is licensed under the MIT License. See the [LICENSE](../../LICENSE.txt) file for details. The sample was adapted from the excellent [Atc.SemanticKernel.Console.Sample](https://github.com/atc-net/atc-semantic-kernel/blob/3adb10d5f5e3c099ce999bbbd5aa4a972073e7f6/sample/Atc.SemanticKernel.Console.Sample/Program.cs) Copyright (c) 2024 [atc-net](https://atc-net.github.io/), which is also licensed under the MIT License.

--- a/samples/SemanticKernel/SemanticKernel.csproj
+++ b/samples/SemanticKernel/SemanticKernel.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference
+      Include="..\..\Adapters.SemanticKernel\Neighborly.Adapters.SemanticKernel.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.14.0-alpha" />
+    <PackageReference Include="Testcontainers" Version="3.8.0" />
+    <PackageReference Include="Atc.SemanticKernel.Connectors.Ollama" Version="1.0.35" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
﻿## 📝 Description

Adds a sample on how to use Neighborly as the text memory for Semantic Kernel.

## 🔗 Related Issues

- Contributes to #15 by showing how to use the `NeighborlyMemoryStore`
- Contributes to #11 by `UpsertAsync` and `GetNearestMatchesAsync`, which were required for the text memory plugin to work. However, I'm not sure if `GetNearestMatchesAsync` is ideal this way, as `VectorDatabase.Search` doesn't expose a similarity score.

## 💡 Additional Notes

- Includes #53 and #54, which I found while creating the sample.
- Includes some minor dependency updates
- Just squash merge this into `master` to avoid the steps inbetween