### PR TITLE
feat: Save and Load indexes to/from the `vectors.bin` file

### DIFF
--- a/Neighborly/Neighborly.csproj
+++ b/Neighborly/Neighborly.csproj
@@ -35,4 +35,8 @@
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Tests" />
+  </ItemGroup>
 </Project>

--- a/Neighborly/Search/BallTree.cs
+++ b/Neighborly/Search/BallTree.cs
@@ -148,5 +148,15 @@ public class BallTree
             .ToList();
     }
 
+    public override bool Equals(object? obj)
+    {
+        if (obj is not BallTree other)
+        {
+            return false;
+        }
+
+        return Equals(root, other.root);
+    }
+
 
 }

--- a/Neighborly/Search/BallTree.cs
+++ b/Neighborly/Search/BallTree.cs
@@ -63,10 +63,9 @@ public class BallTree
         }
     }
 
-    public async Task SaveAsync(BinaryWriter writer, VectorList vectors, CancellationToken cancellationToken = default)
+    public async Task SaveAsync(BinaryWriter writer, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(writer);
-        ArgumentNullException.ThrowIfNull(vectors);
 
         writer.Write(s_currentFileVersion); // Write the version number
 

--- a/Neighborly/Search/BallTreeNode.cs
+++ b/Neighborly/Search/BallTreeNode.cs
@@ -1,16 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Neighborly.Search;
 
-namespace Neighborly.Search
+public class BallTreeNode
 {
-    public class BallTreeNode 
+    public required Vector Center { get; set; }
+    public double Radius { get; set; }
+    public BallTreeNode? Left { get; set; }
+    public BallTreeNode? Right { get; set; }
+
+    internal int Count() => 1 + (Left?.Count() ?? 0) + (Right?.Count() ?? 0);
+
+    internal void WriteTo(BinaryWriter writer, bool treeIdOnly = false)
     {
-        public Vector Center { get; set; }
-        public double Radius { get; set; }
-        public BallTreeNode Left { get; set; }
-        public BallTreeNode Right { get; set; }
+        writer.Write(Center.Id.ToByteArray());
+        if (!treeIdOnly)
+        {
+            writer.Write(Radius);
+            Left?.WriteTo(writer, true);
+            Right?.WriteTo(writer, true);
+        }
     }
 }

--- a/Neighborly/Search/BallTreeNode.cs
+++ b/Neighborly/Search/BallTreeNode.cs
@@ -9,15 +9,12 @@ public class BallTreeNode
 
     internal int Count() => 1 + (Left?.Count() ?? 0) + (Right?.Count() ?? 0);
 
-    internal void WriteTo(BinaryWriter writer, bool treeIdOnly = false)
+    internal void WriteTo(BinaryWriter writer)
     {
         writer.Write(Center.Id.ToByteArray());
-        if (!treeIdOnly)
-        {
-            writer.Write(Radius);
-            Left?.WriteTo(writer, true);
-            Right?.WriteTo(writer, true);
-        }
+        writer.Write(Radius);
+        Left?.WriteTo(writer);
+        Right?.WriteTo(writer);
     }
 
     public override bool Equals(object? obj)

--- a/Neighborly/Search/BallTreeNode.cs
+++ b/Neighborly/Search/BallTreeNode.cs
@@ -19,4 +19,17 @@ public class BallTreeNode
             Right?.WriteTo(writer, true);
         }
     }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is not BallTreeNode other)
+        {
+            return false;
+        }
+
+        return other.Center.Equals(Center) &&
+            other.Radius == Radius &&
+            (other.Left == null && Left == null || other.Left?.Equals(Left) == true) &&
+            (other.Right == null && Right == null || other.Right?.Equals(Right) == true);
+    }
 }

--- a/Neighborly/Search/BallTreeNode.cs
+++ b/Neighborly/Search/BallTreeNode.cs
@@ -7,14 +7,36 @@ public class BallTreeNode
     public BallTreeNode? Left { get; set; }
     public BallTreeNode? Right { get; set; }
 
-    internal int Count() => 1 + (Left?.Count() ?? 0) + (Right?.Count() ?? 0);
-
     internal void WriteTo(BinaryWriter writer)
     {
         writer.Write(Center.Id.ToByteArray());
         writer.Write(Radius);
+        writer.Write(Left != null);
         Left?.WriteTo(writer);
+        writer.Write(Right != null);
         Right?.WriteTo(writer);
+    }
+
+    internal static BallTreeNode? ReadFrom(BinaryReader reader, VectorList vectors, VectorDatabase internalVectors, Span<byte> guidBuffer)
+    {
+        var centerId = reader.ReadGuid(guidBuffer);
+        var center = internalVectors.Vectors.GetById(centerId) ?? vectors.GetById(centerId);
+        if (center is null)
+        {
+            return null;
+        }
+
+        var radius = reader.ReadDouble();
+        var left = reader.ReadBoolean() ? ReadFrom(reader, vectors, internalVectors, guidBuffer) : null;
+        var right = reader.ReadBoolean() ? ReadFrom(reader, vectors, internalVectors, guidBuffer) : null;
+
+        return new BallTreeNode
+        {
+            Center = center,
+            Radius = radius,
+            Left = left,
+            Right = right
+        };
     }
 
     public override bool Equals(object? obj)

--- a/Neighborly/Search/BinaryReaderExtensions.cs
+++ b/Neighborly/Search/BinaryReaderExtensions.cs
@@ -1,0 +1,11 @@
+﻿namespace Neighborly;
+
+internal static class BinaryReaderExtensions
+{
+    public static Guid ReadGuid(this BinaryReader reader, Span<byte> buffer)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+        reader.Read(buffer);
+        return new Guid(buffer);
+    }
+}

--- a/Neighborly/Search/KDTree.cs
+++ b/Neighborly/Search/KDTree.cs
@@ -161,4 +161,14 @@ public class KDTree
         return results;
     }
 
+    public override bool Equals(object? obj)
+    {
+        if (obj is not KDTree other)
+        {
+            return false;
+        }
+
+        return Equals(root, other.root);
+    }
+
 }

--- a/Neighborly/Search/KDTree.cs
+++ b/Neighborly/Search/KDTree.cs
@@ -2,100 +2,163 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Neighborly.Search
+namespace Neighborly.Search;
+
+/// <summary>
+/// K-D Tree search (see Wikipedia: https://en.wikipedia.org/wiki/K-d_tree)
+/// </summary>
+public class KDTree
 {
     /// <summary>
-    /// K-D Tree search (see Wikipedia: https://en.wikipedia.org/wiki/K-d_tree)
+    /// The version of the database file format that this class writes.
     /// </summary>
-    public class KDTree
+    private const int s_currentFileVersion = 1;
+
+    private KDTreeNode? root;
+
+    public void Build(VectorList vectors)
     {
-        private KDTreeNode? root;
-
-        public void Build(VectorList vectors)
+        if (vectors == null)
         {
-            if (vectors == null)
-            {
-                throw new ArgumentNullException(nameof(vectors), "Vector list cannot be null");
-            }
-            if (vectors.Count == 0)
-            {
-                return;
-            }
-
-            root = Build(vectors, 0);
+            throw new ArgumentNullException(nameof(vectors), "Vector list cannot be null");
+        }
+        if (vectors.Count == 0)
+        {
+            return;
         }
 
-        private KDTreeNode? Build(IList<Vector> vectors, int depth)
+        root = Build(vectors, 0);
+    }
+
+    public void Load(BinaryReader reader, VectorList vectors)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+        ArgumentNullException.ThrowIfNull(vectors);
+
+        var version = reader.ReadInt32(); // Read the version number
+        if (version != s_currentFileVersion)
         {
-            if (!vectors.Any() || vectors[0].Dimensions == 0)
-                return null;
-
-            var axis = depth % vectors[0].Dimensions;
-            var sortedVectors = vectors.OrderBy(v => v[axis]).ToList();
-
-            var median = sortedVectors.Count / 2;
-
-            return new KDTreeNode
-            {
-                Vector = sortedVectors[median],
-                Left = Build(sortedVectors.Take(median).ToList(), depth + 1),
-                Right = Build(sortedVectors.Skip(median + 1).ToList(), depth + 1)
-            };
+            throw new InvalidDataException($"Invalid KD tree version: {version}");
         }
 
-        public IList<Vector> NearestNeighbors(Vector query, int k)
+        root = null;
+        var entries = reader.ReadInt32();
+        // Layout of the each entry in the file:
+        // - Center (Guid)
+        // - Left (Guid of the Vector in the left node)
+        // - Right (Guid of the Vector in the left node)
+        Span<byte> guidBuffer = stackalloc byte[16];
+        List<(Vector center, Vector? left, Vector? right)> nodes = new(entries);
+        for (var i = 0; i < entries; i++)
         {
-            if (query == null)
+            // Read the entry
+            var center = reader.ReadGuid(guidBuffer);
+            var left = reader.ReadGuid(guidBuffer);
+            var right = reader.ReadGuid(guidBuffer);
+
+            // Find the vectors
+            var centerVector = vectors.GetById(center);
+            if (centerVector is null)
             {
-                throw new ArgumentNullException(nameof(query), "Query vector cannot be null");
-            }
-            if (k <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(k), "Number of neighbors must be greater than 0");
+                throw new InvalidDataException($"Vector not found: {center}");
             }
 
-            return NearestNeighbors(root, query, k, 0)?
-                .OrderBy(t => (t.Item1 - query).Magnitude)
-                .Select(t => t.Item1)
-                .ToList() ?? new List<Vector>();
+            var leftVector = vectors.GetById(left);
+            var rightVector = vectors.GetById(right);
+            nodes.Add((centerVector, leftVector, rightVector));
+        }
+    }
 
+    public void Save(BinaryWriter writer, VectorList vectors)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(vectors);
+
+        writer.Write(s_currentFileVersion); // Write the version number
+        var entries = root?.Count() ?? 0;
+        writer.Write(entries);
+
+        root?.WriteTo(writer);
+    }
+
+    private KDTreeNode? Build(IList<Vector> vectors, int depth)
+    {
+        if (vectors.Count <= 0)
+        {
+            return null;
         }
 
-        private List<Tuple<Vector, double>>? NearestNeighbors(KDTreeNode? node, Vector query, int k, int depth)
+        var firstVector = vectors[0];
+        if (firstVector.Dimensions == 0)
         {
-            if (node == null || node.Vector == null)
-                return new List<Tuple<Vector, double>>();
+            return null;
+        }
 
-            var axis = depth % query.Dimensions;
-            var next = node.Vector[axis] > query[axis] ? node.Left : node.Right;
-            var others = node.Vector[axis] > query[axis] ? node.Right : node.Left;
+        var axis = depth % firstVector.Dimensions;
+        var sortedVectors = vectors.OrderBy(v => v[axis]).ToList();
 
-            var best = NearestNeighbors(next, query, k, depth + 1) ?? new List<Tuple<Vector, double>>();
+        var median = sortedVectors.Count / 2;
+
+        return new KDTreeNode
+        {
+            Vector = sortedVectors[median],
+            Left = Build(sortedVectors.Take(median).ToList(), depth + 1),
+            Right = Build(sortedVectors.Skip(median + 1).ToList(), depth + 1)
+        };
+    }
+
+    public IList<Vector> NearestNeighbors(Vector query, int k)
+    {
+        if (query == null)
+        {
+            throw new ArgumentNullException(nameof(query), "Query vector cannot be null");
+        }
+        if (k <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(k), "Number of neighbors must be greater than 0");
+        }
+
+        return NearestNeighbors(root, query, k, 0)?
+            .OrderBy(t => (t.Item1 - query).Magnitude)
+            .Select(t => t.Item1)
+            .ToList() ?? [];
+
+    }
+
+    private List<Tuple<Vector, double>>? NearestNeighbors(KDTreeNode? node, Vector query, int k, int depth)
+    {
+        if (node == null || node.Vector == null)
+            return [];
+
+        var axis = depth % query.Dimensions;
+        var next = node.Vector[axis] > query[axis] ? node.Left : node.Right;
+        var others = node.Vector[axis] > query[axis] ? node.Right : node.Left;
+
+        var best = NearestNeighbors(next, query, k, depth + 1) ?? [];
+        if (best.Count < k || Math.Abs(node.Vector[axis] - query[axis]) < best.Last().Item2)
+        {
+            var distance = (node.Vector - query).Magnitude;
+            best.Add(Tuple.Create(node.Vector, (double)distance));
+            best = best.OrderBy(t => t.Item2).Take(k).ToList();
+
             if (best.Count < k || Math.Abs(node.Vector[axis] - query[axis]) < best.Last().Item2)
             {
-                var distance = (node.Vector - query).Magnitude;
-                best.Add(Tuple.Create(node.Vector, (double)distance));
-                best = best.OrderBy(t => t.Item2).Take(k).ToList();
-
-                if (best.Count < k || Math.Abs(node.Vector[axis] - query[axis]) < best.Last().Item2)
-                {
-                    best = best.Concat(NearestNeighbors(others, query, k, depth + 1) ?? new List<Tuple<Vector, double>>())
-                        .OrderBy(t => t.Item2)
-                        .Take(k)
-                        .ToList();
-                }
+                best = best.Concat(NearestNeighbors(others, query, k, depth + 1) ?? [])
+                    .OrderBy(t => t.Item2)
+                    .Take(k)
+                    .ToList();
             }
-
-            return best;
         }
 
-        public IList<Vector> Search(Vector query, int k)
-        {
-            // Perform the nearest neighbor search
-            var results = NearestNeighbors(query, k);
-
-            return results;
-        }
-       
+        return best;
     }
+
+    public IList<Vector> Search(Vector query, int k)
+    {
+        // Perform the nearest neighbor search
+        var results = NearestNeighbors(query, k);
+
+        return results;
+    }
+
 }

--- a/Neighborly/Search/KDTreeNode.cs
+++ b/Neighborly/Search/KDTreeNode.cs
@@ -1,15 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Neighborly.Search;
 
-namespace Neighborly.Search
+public class KDTreeNode
 {
-    public class KDTreeNode
+    public required Vector Vector { get; set; }
+    public KDTreeNode? Left { get; set; }
+    public KDTreeNode? Right { get; set; }
+
+    internal int Count() => 1 + (Left?.Count() ?? 0) + (Right?.Count() ?? 0);
+
+    internal void WriteTo(BinaryWriter writer)
     {
-        public Vector? Vector { get; set; }
-        public KDTreeNode? Left { get; set; }
-        public KDTreeNode? Right { get; set; }
+        writer.Write(Vector.Id.ToByteArray());
+        Left?.WriteTo(writer);
+        Right?.WriteTo(writer);
     }
 }

--- a/Neighborly/Search/KDTreeNode.cs
+++ b/Neighborly/Search/KDTreeNode.cs
@@ -6,13 +6,33 @@ public class KDTreeNode
     public KDTreeNode? Left { get; set; }
     public KDTreeNode? Right { get; set; }
 
-    internal int Count() => 1 + (Left?.Count() ?? 0) + (Right?.Count() ?? 0);
-
     internal void WriteTo(BinaryWriter writer)
     {
         writer.Write(Vector.Id.ToByteArray());
+        writer.Write(Left != null);
         Left?.WriteTo(writer);
+        writer.Write(Right != null);
         Right?.WriteTo(writer);
+    }
+
+    internal static KDTreeNode? ReadFrom(BinaryReader reader, VectorList vectors, Span<byte> guidBuffer)
+    {
+        var vectorId = reader.ReadGuid(guidBuffer);
+        var vector = vectors.GetById(vectorId);
+        if (vector is null)
+        {
+            return null;
+        }
+
+        var left = reader.ReadBoolean() ? ReadFrom(reader, vectors, guidBuffer) : null;
+        var right = reader.ReadBoolean() ? ReadFrom(reader, vectors, guidBuffer) : null;
+
+        return new KDTreeNode
+        {
+            Vector = vector,
+            Left = left,
+            Right = right
+        };
     }
 
     public override bool Equals(object? obj)

--- a/Neighborly/Search/KDTreeNode.cs
+++ b/Neighborly/Search/KDTreeNode.cs
@@ -14,4 +14,16 @@ public class KDTreeNode
         Left?.WriteTo(writer);
         Right?.WriteTo(writer);
     }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is not KDTreeNode other)
+        {
+            return false;
+        }
+
+        return other.Vector.Equals(Vector) &&
+            (other.Left == null && Left == null || other.Left?.Equals(Left) == true) &&
+            (other.Right == null && Right == null || other.Right?.Equals(Right) == true);
+    }
 }

--- a/Neighborly/Search/SearchService.cs
+++ b/Neighborly/Search/SearchService.cs
@@ -111,7 +111,7 @@ namespace Neighborly.Search
                         _kdTree.Load(reader, _vectors);
                         break;
                     case SearchAlgorithm.BallTree:
-                        _ballTree.Load(reader, _vectors);
+                        await _ballTree.LoadAsync(reader, _vectors, cancellationToken).ConfigureAwait(false);
                         break;
                     default:
                         throw new InvalidOperationException("Unsupported search method");
@@ -119,7 +119,7 @@ namespace Neighborly.Search
             }
         }
 
-        public Task SaveAsync(BinaryWriter writer, CancellationToken cancellationToken = default)
+        public async Task SaveAsync(BinaryWriter writer, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(writer);
 
@@ -127,14 +127,13 @@ namespace Neighborly.Search
             writer.Write(s_numberOfStorableIndexes); // Write the number of indexes
 
             cancellationToken.ThrowIfCancellationRequested();
-            ExportIndex(writer, SearchAlgorithm.KDTree);
+            await ExportIndexAsync(writer, SearchAlgorithm.KDTree).ConfigureAwait(false);
 
             cancellationToken.ThrowIfCancellationRequested();
-            ExportIndex(writer, SearchAlgorithm.BallTree);
-            return Task.CompletedTask;
+            await ExportIndexAsync(writer, SearchAlgorithm.BallTree).ConfigureAwait(false);
         }
 
-        private void ExportIndex(BinaryWriter writer, SearchAlgorithm method)
+        private async Task ExportIndexAsync(BinaryWriter writer, SearchAlgorithm method)
         {
             writer.Write((int)method);
 
@@ -144,7 +143,7 @@ namespace Neighborly.Search
                     _kdTree.Save(writer, _vectors);
                     break;
                 case SearchAlgorithm.BallTree:
-                    _ballTree.Save(writer, _vectors);
+                    await _ballTree.SaveAsync(writer, _vectors).ConfigureAwait(false);
                     break;
                 default:
                     throw new InvalidOperationException("Unsupported search method");

--- a/Neighborly/Search/SearchService.cs
+++ b/Neighborly/Search/SearchService.cs
@@ -127,13 +127,13 @@ namespace Neighborly.Search
             writer.Write(s_numberOfStorableIndexes); // Write the number of indexes
 
             cancellationToken.ThrowIfCancellationRequested();
-            await ExportIndexAsync(writer, SearchAlgorithm.KDTree).ConfigureAwait(false);
+            await ExportIndexAsync(writer, SearchAlgorithm.KDTree, cancellationToken).ConfigureAwait(false);
 
             cancellationToken.ThrowIfCancellationRequested();
-            await ExportIndexAsync(writer, SearchAlgorithm.BallTree).ConfigureAwait(false);
+            await ExportIndexAsync(writer, SearchAlgorithm.BallTree, cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task ExportIndexAsync(BinaryWriter writer, SearchAlgorithm method)
+        private async Task ExportIndexAsync(BinaryWriter writer, SearchAlgorithm method, CancellationToken cancellationToken)
         {
             writer.Write((int)method);
 
@@ -143,7 +143,7 @@ namespace Neighborly.Search
                     _kdTree.Save(writer, _vectors);
                     break;
                 case SearchAlgorithm.BallTree:
-                    await _ballTree.SaveAsync(writer, _vectors).ConfigureAwait(false);
+                    await _ballTree.SaveAsync(writer, cancellationToken).ConfigureAwait(false);
                     break;
                 default:
                     throw new InvalidOperationException("Unsupported search method");

--- a/Neighborly/VectorDatabase.cs
+++ b/Neighborly/VectorDatabase.cs
@@ -1,9 +1,8 @@
-﻿using Neighborly.ETL;
-using Microsoft.Extensions.Logging;
-using System.IO.Compression;
+﻿using Microsoft.Extensions.Logging;
+using Neighborly.ETL;
 using Neighborly.Search;
 using System.Diagnostics;
-using CsvHelper;
+using System.IO.Compression;
 
 namespace Neighborly;
 
@@ -12,13 +11,18 @@ namespace Neighborly;
 /// </summary>
 public partial class VectorDatabase
 {
+    /// <summary>
+    /// The version of the database file format that this class writes.
+    /// </summary>
+    private const int s_currentFileVersion = 1;
+
     private readonly ILogger<VectorDatabase> _logger = Logging.LoggerFactory.CreateLogger<VectorDatabase>();
     private readonly Instrumentation _instrumentation;
     /// <summary>
     /// The unique identifier of the database for telemetry purposes.
     /// </summary>
     private readonly Guid _id = Guid.NewGuid();
-    private readonly VectorList _vectors = new();
+    private readonly VectorList _vectors = new(1337);
     private readonly System.Diagnostics.Metrics.Counter<long> _indexRebuildCounter;
     public VectorList Vectors => _vectors;
     private Search.SearchService _searchService;
@@ -27,7 +31,7 @@ public partial class VectorDatabase
     /// <summary>
     /// Last time the database was modified. This is updated when a vector is added or removed.
     /// </summary>
-    private DateTime lastModification = DateTime.Now;
+    private DateTime _lastModification = DateTime.UtcNow;
 
     /// <summary>
     /// The time threshold in seconds for rebuilding the search indexes and VectorTags after a database change was detected.
@@ -61,7 +65,7 @@ public partial class VectorDatabase
 
     private void VectorList_Modified(object? sender, EventArgs e)
     {
-        lastModification = DateTime.Now;
+        _lastModification = DateTime.UtcNow;
         _hasUnsavedChanges = true;
         _hasOutdatedIndex = true;
     }
@@ -77,7 +81,7 @@ public partial class VectorDatabase
             CouldNotFindVectorInDb(query, k, ex);
             return new List<Vector>();
         }
-            
+
     }
 
     [LoggerMessage(
@@ -93,10 +97,6 @@ public partial class VectorDatabase
     public VectorDatabase()
         : this(Logging.LoggerFactory.CreateLogger<VectorDatabase>(), null)
     {
-        // Wire up the event handler for the VectorList.Modified event
-        _vectors.Modified += VectorList_Modified;
-        _searchService = new Search.SearchService(_vectors);
-        StartIndexService();
     }
 
     /// <summary>
@@ -125,6 +125,7 @@ public partial class VectorDatabase
             tags: [new("db.namespace", _id)]
         );
 
+        // Wire up the event handler for the VectorList.Modified event
         _vectors.Modified += VectorList_Modified;
         _searchService = new Search.SearchService(_vectors);
         StartIndexService();
@@ -138,13 +139,13 @@ public partial class VectorDatabase
     /// </summary>
     /// <param name="path">The file path to load the vectors from.</param>
     /// <param name="createOnNew">Indicates whether to create a new file if it doesn't exist.</param>
-    public async Task LoadAsync(string path, bool createOnNew = true)
+    public async Task LoadAsync(string path, bool createOnNew = true, CancellationToken cancellationToken = default)
     {
         string filePath = Path.Combine(path, "vectors.bin");
         bool fileExists = File.Exists(filePath);
         if (!createOnNew && !fileExists)
         {
-            _logger.LogError($"The file {filePath} does not exist.");
+            _logger.LogError("The file {FilePath} does not exist.", filePath);
             throw new FileNotFoundException($"The file {filePath} does not exist.");
         }
         else if (createOnNew && !fileExists)
@@ -157,26 +158,30 @@ public partial class VectorDatabase
             _rwLock.EnterWriteLock();
             try
             {
+                bool indexesAreDirty;
+
                 using (var inputStream = new FileStream(filePath, FileMode.Open))
                 using (var decompressionStream = new GZipStream(inputStream, CompressionMode.Decompress))
                 using (var reader = new BinaryReader(decompressionStream))
                 {
                     _vectors.Clear();
-                    var vectorCount = reader.ReadInt32();   // Total number of Vectors in the database
+                    var fileVersion = reader.ReadInt32();   // File version
 
-                    for (int i = 0; i < vectorCount; i++)
+                    Func<BinaryReader, CancellationToken, Task<(int vectorCount, bool indexesAreDirty)>> importFunc = fileVersion switch
                     {
-                        var nextVector = reader.ReadInt32();    // File offset of the next Vector
-                        var vector = new Vector(reader.ReadBytes(nextVector));
-                        _vectors.Add(vector);
-                    }
-                    Console.WriteLine(inputStream.Name);
-                    reader.Close();
-                    inputStream.Close();
+                        1 => LoadV1Async,
+                        _ => LoadV0Async
+                    };
+
+                    (int vectorCount, indexesAreDirty) = await importFunc(reader, cancellationToken).ConfigureAwait(false);
+                    _logger.LogInformation("Loaded {VectorCount} vectors from {FilePath}.", vectorCount, inputStream.Name);
                 }
 
-                await RebuildSearchIndexesAsync();     // Rebuild both k-d tree and Ball Tree search index  
-                
+                if (indexesAreDirty)
+                {
+                    await RebuildSearchIndexesAsync().ConfigureAwait(false);     // Rebuild both k-d tree and Ball Tree search index  
+                }
+
                 _vectors.Tags.BuildMap();   // Rebuild the tag map
                 _hasUnsavedChanges = false; // Set the flag to indicate the database hasn't been modified
                 _hasOutdatedIndex = false;  // Set the flag to indicate the index is up-to-date
@@ -189,7 +194,43 @@ public partial class VectorDatabase
                 }
             }
         }
+    }
 
+    /// <summary>
+    /// Imports vectors from a specified file path with the V1 layout.
+    /// </summary>
+    /// <remarks>
+    /// The V1 layout has a leading integer that indicates the total number of vectors in the database
+    /// followed by the binary representation of each vector. Up to this, the V0 layout is the same.
+    /// However, it is followed by the binary representation the indexes.
+    /// </remarks>
+    private async Task<(int vectorCount, bool indexesAreDirty)> LoadV1Async(BinaryReader reader, CancellationToken cancellationToken = default)
+    {
+        var (vectorCount, _) = await LoadV0Async(reader, cancellationToken).ConfigureAwait(false);
+        await _searchService.LoadAsync(reader, cancellationToken).ConfigureAwait(false);
+        return (vectorCount, false);
+    }
+
+    /// <summary>
+    /// Imports vectors from a specified file path with the original layout.
+    /// </summary>
+    /// <remarks>
+    /// The original layout has a leading integer that indicates the total number of vectors in the database
+    /// followed by the binary representation of each vector.
+    /// </remarks>
+    private Task<(int vectorCount, bool indexesAreDirty)> LoadV0Async(BinaryReader reader, CancellationToken cancellationToken = default)
+    {
+        var vectorCount = reader.ReadInt32();   // Total number of Vectors in the database
+
+        for (int i = 0; i < vectorCount; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var nextVector = reader.ReadInt32();    // File offset of the next Vector
+            var vector = new Vector(reader.ReadBytes(nextVector));
+            _vectors.Add(vector);
+        }
+
+        return Task.FromResult((vectorCount, true));
     }
 
     private void StartIndexService()
@@ -208,7 +249,7 @@ public partial class VectorDatabase
                 // If the database has been modified and the last modification was more than 5 seconds ago, rebuild the indexes
                 if (_hasOutdatedIndex &&
                     _vectors.Count > 0 &&
-                    DateTime.Now.Subtract(lastModification).TotalSeconds > timeThresholdSeconds)
+                    DateTime.UtcNow.Subtract(_lastModification).TotalSeconds > timeThresholdSeconds)
                 {
                     await RebuildTagsAsync();
                     await RebuildSearchIndexesAsync();
@@ -267,13 +308,13 @@ public partial class VectorDatabase
     /// <summary>
     /// Saves the vectors to the current directory.
     /// </summary>
-    public async Task SaveAsync()
+    public async Task SaveAsync(CancellationToken cancellationToken = default)
     {
         // Get the current directory
         string currentDirectory = Directory.GetCurrentDirectory();
 
         // Call the existing Save method with the current directory
-        await SaveAsync(currentDirectory);
+        await SaveAsync(currentDirectory, cancellationToken);
     }
 
     /// <summary>
@@ -281,7 +322,7 @@ public partial class VectorDatabase
     /// (In the API server, this method will be called when the host OS sends a shutdown signal.)
     /// </summary>
     /// <param name="path">The file path to save the vectors to.</param>
-    public async Task SaveAsync(string path)
+    public async Task SaveAsync(string path, CancellationToken cancellationToken = default)
     {
         // If the database hasn't been modified, no need to save it
         if (!_hasUnsavedChanges)
@@ -299,21 +340,23 @@ public partial class VectorDatabase
             _rwLock.EnterWriteLock();
             // Save the vectors to a binary file
             string filePath = Path.Combine(path, "vectors.bin");
-            var outputStream = new FileStream(filePath, FileMode.Create);
+            using var outputStream = new FileStream(filePath, FileMode.Create);
             // TODO -- Experiment with other compression types. For now, GZip works.
             using (var compressionStream = new GZipStream(outputStream, CompressionLevel.Fastest))
             using (var writer = new BinaryWriter(compressionStream))
             {
                 // TODO -- This should be async and potentially parallelized
+                writer.Write(s_currentFileVersion);
                 writer.Write(_vectors.Count);
                 foreach (Vector v in _vectors)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     byte[] bytes = v.ToBinary();
                     writer.Write(bytes.Length);    // File offset of the next Vector
                     writer.Write(bytes);           // The Vector itself
                 }
-                writer.Close();
-                outputStream.Close();
+
+                await _searchService.SaveAsync(writer, cancellationToken).ConfigureAwait(false);
             }
 
             _hasUnsavedChanges = false; // Set the flag to indicate the database hasn't been modified
@@ -334,8 +377,6 @@ public partial class VectorDatabase
         {
             _rwLock.ExitWriteLock();
         }
-
-        
     }
     #endregion
 

--- a/Neighborly/VectorList.cs
+++ b/Neighborly/VectorList.cs
@@ -311,6 +311,26 @@ public class VectorList : IList<Vector>, IDisposable
 
     }
 
+    internal Vector? GetById(Guid id)
+    {
+        lock (_lock)
+        {
+            if (Guid.Empty.Equals(id))
+            {
+                // Return default if id is empty
+                return default;
+            }
+
+            var index = FindIndexById(id);
+            if (index != -1)
+            {
+                return Get(index);
+            }
+
+            return default;
+        }
+    }
+
     public bool Remove(Vector item)
     {
         var index = _vectorList.FindIndex(x => x != null && x.Equals(item));

--- a/Tests/BallTreeTests.cs
+++ b/Tests/BallTreeTests.cs
@@ -1,0 +1,34 @@
+﻿using System.Text;
+using Neighborly.Search;
+
+namespace Neighborly.Tests;
+
+[TestFixture]
+public class BallTreeTests
+{
+    [Test]
+    public async Task CanSaveAndLoad()
+    {
+        // Arrange
+        BallTree originalTree = new();
+        VectorList vectors = [new Vector([1f, 2, 3]), new Vector([4f, 5, 6]), new Vector([7f, 8, 9])];
+        originalTree.Build(vectors);
+
+        // Act
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, Encoding.UTF8, true))
+        {
+            await originalTree.SaveAsync(writer, vectors).ConfigureAwait(true);
+        }
+
+        stream.Seek(0, SeekOrigin.Begin);
+        BallTree loadedTree = new();
+        using (var reader = new BinaryReader(stream))
+        {
+            await loadedTree.LoadAsync(reader, vectors).ConfigureAwait(true);
+        }
+
+        // Assert
+        Assert.That(loadedTree, Is.EqualTo(originalTree));
+    }
+}

--- a/Tests/BallTreeTests.cs
+++ b/Tests/BallTreeTests.cs
@@ -18,12 +18,12 @@ public class BallTreeTests
         using var stream = new MemoryStream();
         using (var writer = new BinaryWriter(stream, Encoding.UTF8, true))
         {
-            await originalTree.SaveAsync(writer, vectors).ConfigureAwait(true);
+            await originalTree.SaveAsync(writer).ConfigureAwait(true);
         }
 
         stream.Seek(0, SeekOrigin.Begin);
         BallTree loadedTree = new();
-        using (var reader = new BinaryReader(stream))
+        using (var reader = new BinaryReader(stream, Encoding.UTF8, true))
         {
             await loadedTree.LoadAsync(reader, vectors).ConfigureAwait(true);
         }

--- a/Tests/KDTreeTests.cs
+++ b/Tests/KDTreeTests.cs
@@ -1,0 +1,35 @@
+﻿using System.Text;
+using Neighborly.Search;
+
+namespace Neighborly.Tests;
+
+[TestFixture]
+public class KDTreeTests
+{
+    [Test]
+    public void CanSaveAndLoad()
+    {
+        // Arrange
+        KDTree originalTree = new();
+        VectorList vectors = [new Vector([1f, 2, 3]), new Vector([4f, 5, 6]), new Vector([7f, 8, 9])];
+        originalTree.Build(vectors);
+
+        // Act
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, Encoding.UTF8, true))
+        {
+            originalTree.Save(writer, vectors);
+        }
+
+        stream.Seek(0, SeekOrigin.Begin);
+        KDTree loadedTree = new();
+        using (var reader = new BinaryReader(stream))
+        {
+            loadedTree.Load(reader, vectors);
+        }
+
+        // Assert
+        Assert.That(loadedTree, Is.EqualTo(originalTree));
+    }
+
+}

--- a/Tests/VectorDatabaseTests.cs
+++ b/Tests/VectorDatabaseTests.cs
@@ -255,9 +255,11 @@ public class VectorDatabaseTests
         _db.Vectors.Add(vector1);
         _db.Vectors.Add(vector2);
 
+        await _db.RebuildSearchIndexesAsync().ConfigureAwait(true);
+
         var path = Path.GetTempPath();
 
-        // Act
+        // Act    
         await _db.SaveAsync(path).ConfigureAwait(true);
         _db.Vectors.Clear();
         await _db.LoadAsync(path).ConfigureAwait(true);


### PR DESCRIPTION
﻿## 📝 Description

Proposal for saving and loading the indexes to the vector file.

## 🔗 Related Issues

Fixes #45

## 💡 Additional Notes

This adds versioning to the binary file, so that, should a new binary layout be introduced, older versions could be supported for a while.