### PR TITLE
fix: Dispose `VectorDatabase` and `VectorList` instances

### DIFF
--- a/Neighborly/Search/BallTree.cs
+++ b/Neighborly/Search/BallTree.cs
@@ -56,7 +56,7 @@ public class BallTree
         root = null;
 
         // Read internal vectors (centers of internal nodes)
-        var internalVectors = new VectorDatabase();
+        using var internalVectors = new VectorDatabase();
         await internalVectors.ReadFromAsync(reader, false, cancellationToken).ConfigureAwait(false);
 
         byte[] guidBuffer = new byte[16];
@@ -71,7 +71,7 @@ public class BallTree
         writer.Write(s_currentFileVersion); // Write the version number
 
         // Write internal vectors (centers of internal nodes)
-        var internalVectors = BuildInternalVectors(root);
+        using var internalVectors = BuildInternalVectors(root);
         await internalVectors.WriteToAsync(writer, false, cancellationToken).ConfigureAwait(false);
 
         root?.WriteTo(writer);

--- a/Neighborly/VectorDatabase.cs
+++ b/Neighborly/VectorDatabase.cs
@@ -9,7 +9,7 @@ namespace Neighborly;
 /// <summary>
 /// Represents a database for storing and searching vectors.
 /// </summary>
-public partial class VectorDatabase
+public partial class VectorDatabase : IDisposable
 {
     /// <summary>
     /// The version of the database file format that this class writes.
@@ -57,6 +57,8 @@ public partial class VectorDatabase
     /// Indicates whether the database has changed since the last indexing, and it needs to be rebuilt.
     /// </summary>
     private bool _hasOutdatedIndex = false;
+
+    private bool _disposedValue;
 
     /// <summary>
     /// Gets a value indicating whether the database has been modified since the last save.
@@ -413,5 +415,27 @@ public partial class VectorDatabase
         return etl.ExportDataAsync(Vectors, path, cancellationToken);
     }
     #endregion
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposedValue)
+        {
+            if (disposing)
+            {
+                _rwLock.Dispose();
+                _vectors.Modified -= VectorList_Modified;
+                _vectors.Dispose();
+            }
+
+            _disposedValue = true;
+        }
+    }
+
+    public void Dispose()
+    {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
 
 }

--- a/Neighborly/VectorList.cs
+++ b/Neighborly/VectorList.cs
@@ -76,11 +76,6 @@ public class VectorList : IList<Vector>, IDisposable
         GC.SuppressFinalize(this);
     }
 
-    ~VectorList()
-    {
-        Dispose(false);
-    }
-
     public void Add(Vector item)
     {
         ArgumentNullException.ThrowIfNull(item);

--- a/Tests/BallTreeTests.cs
+++ b/Tests/BallTreeTests.cs
@@ -11,7 +11,7 @@ public class BallTreeTests
     {
         // Arrange
         BallTree originalTree = new();
-        VectorList vectors = [new Vector([1f, 2, 3]), new Vector([4f, 5, 6]), new Vector([7f, 8, 9])];
+        using VectorList vectors = [new Vector([1f, 2, 3]), new Vector([4f, 5, 6]), new Vector([7f, 8, 9])];
         originalTree.Build(vectors);
 
         // Act

--- a/Tests/LoggingTests.cs
+++ b/Tests/LoggingTests.cs
@@ -16,6 +16,12 @@ public class LoggingTests
         _db = new VectorDatabase(_logger, null);
     }
 
+    [TearDown]
+    public void TearDown()
+    {
+        _db.Dispose();
+    }
+
     [Test]
     public async Task TestMethodThatShouldLogError()
     {

--- a/Tests/MemoryMappedFileTests.cs
+++ b/Tests/MemoryMappedFileTests.cs
@@ -18,9 +18,15 @@ namespace Tests
         [SetUp]
         public void Setup()
         {
-            _db?.Vectors?.Dispose();
+            _db?.Dispose();
 
             _db = new VectorDatabase();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _db.Dispose();
         }
 
         [Test]

--- a/Tests/VectorDatabaseTests.cs
+++ b/Tests/VectorDatabaseTests.cs
@@ -11,9 +11,15 @@ public class VectorDatabaseTests
     [SetUp]
     public void Setup()
     {
-        _db?.Vectors?.Dispose();
+        _db?.Dispose();
 
         _db = new VectorDatabase();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _db.Dispose();
     }
 
     // Replace all Assert.AreEqual calls with Assert.That calls
@@ -354,13 +360,12 @@ public class VectorDatabaseTests
     {
         // Arrange
         var logger = new MockLogger<VectorDatabase>();
-        var db = new VectorDatabase(logger, null) { };
 
         var query = new Vector([1f, 2f, 3f]);
         var k = -1;
 
         // Act
-        db.Search(query, k);
+        _db.Search(query, k);
 
         // Assert
         Assert.That(logger.LastLogLevel, Is.EqualTo(LogLevel.Error), "An error should be logged.");

--- a/VectorDatabaseTests.cs
+++ b/VectorDatabaseTests.cs
@@ -8,7 +8,7 @@ public class VectorDatabaseTests
     [Test]
     public void TestAdd()
     {
-        var db = new VectorDatabase();
+        using var db = new VectorDatabase();
         var vector = new Vector(1, 2, 3);
         db.Add(vector);
         Assert.AreEqual(1, db.Count);
@@ -18,7 +18,7 @@ public class VectorDatabaseTests
     [Test]
     public void TestRemove()
     {
-        var db = new VectorDatabase();
+        using var db = new VectorDatabase();
         var vector = new Vector(1, 2, 3);
         db.Add(vector);
         db.Remove(vector);
@@ -29,7 +29,7 @@ public class VectorDatabaseTests
     [Test]
     public void TestUpdate()
     {
-        var db = new VectorDatabase();
+        using var db = new VectorDatabase();
         var oldVector = new Vector(1, 2, 3);
         var newVector = new Vector(4, 5, 6);
         db.Add(oldVector);
@@ -42,7 +42,7 @@ public class VectorDatabaseTests
     [Test]
     public void TestAddRange()
     {
-        var db = new VectorDatabase();
+        using var db = new VectorDatabase();
         var vectors = new List<Vector> { new Vector(1, 2, 3), new Vector(4, 5, 6) };
         db.AddRange(vectors);
         Assert.AreEqual(2, db.Count);
@@ -55,7 +55,7 @@ public class VectorDatabaseTests
     [Test]
     public void TestRemoveRange()
     {
-        var db = new VectorDatabase();
+        using var db = new VectorDatabase();
         var vectors = new List<Vector> { new Vector(1, 2, 3), new Vector(4, 5, 6) };
         db.AddRange(vectors);
         db.RemoveRange(vectors);

--- a/samples/SemanticKernel/Program.cs
+++ b/samples/SemanticKernel/Program.cs
@@ -45,7 +45,7 @@ OllamaTextGenerationService ollamaText = new(ollamaUri, modelName);
 OllamaTextEmbeddingGenerationService ollamaEmbedding = new(ollamaUri, embeddingModelName);
 
 #pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-var db = new VectorDatabase(loggerFactory.CreateLogger<VectorDatabase>(), null);
+using var db = new VectorDatabase(loggerFactory.CreateLogger<VectorDatabase>(), null);
 var memory = new MemoryBuilder()
     .WithLoggerFactory(loggerFactory)
     .WithMemoryStore(new NeighborlyMemoryStore(db)) // Use NeighborlyMemoryStore


### PR DESCRIPTION
﻿## 📝 Description

Makes `VectorDatabase` implement `IDisposable`, and disposes `VectorDatabase` and `VectorList` where necessary.

## 🔗 Related Issues

Contributes to #62 by fixing the pressing issue, but a stable operation on Windows might require better memory management, ie. based on #2.

## 💡 Additional Notes

Maybe set up some static code analysis like SonarCloud and/or CodeQL to catch missing memory clean-up?