### PR TITLE
ci: Run tests on latest windows and ubuntu runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
﻿## 📝 Description

Ensure that tests succeed (right now, fail) on both platforms.

## 🔗 Related Issues

None

## 💡 Additional Notes

I believe this to be helpful, because we've both noticed some platform specific differences/issues, especially when working with `MemoryMappedFile`. It needs to be seen if the public GitHub actions runners can run with the memory requirements.